### PR TITLE
added older versions

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -142,3 +142,14 @@ For all Yii packages GitHub repository name exactly matches Packagist package na
 [yiisoft/db-mongodb]:           https://github.com/yiisoft/db-mongodb
 [yiisoft/db-elasticsearch]:     https://github.com/yiisoft/db-elasticsearch
 
+---
+
+## Older versions
+
+| Package                       | Title                                 | Description                       | Status
+|-------------------------------|---------------------------------------|-----------------------------------|-------------
+| [yiisoft/yii]                 | Yii Framework 1.x                     | Full-stack web-framework          | [![Build Status](https://secure.travis-ci.org/yiisoft/yii.png)](http://travis-ci.org/yiisoft/yii)
+| [yiisoft/yii2]                | Yii Framework 2.x                     | Full-stack web-framework          | [![Build Status](https://secure.travis-ci.org/yiisoft/yii2.png)](http://travis-ci.org/yiisoft/yii2)
+
+[yiisoft/yii]:                  https://github.com/yiisoft/yii
+[yiisoft/yii2]:                  https://github.com/yiisoft/yii2


### PR DESCRIPTION
Might also be worth adding some info about:
- https://github.com/yiisoft/yii-framework
- https://github.com/yiisoft/yii2-framework

I also saw some projects marking their outdated projects with a :skull: (or similar) in the GitHub description, which makes it easier to grasp that you are viewing an outdated repo.