### PR TITLE
Remove `Exception: PHP 7.4 MIGHT not be considered.` from docs

### DIFF
--- a/000-packages.md
+++ b/000-packages.md
@@ -68,7 +68,6 @@ The support of PHP versions supported for a package depends on
   These SHOULD correspond to PHP versions receiving security fixes.
 - Packages and application templates MIGHT have supported versions that work with unsupported PHP versions.
 - Bumping minimal PHP version in a package or an application template is considered a minor change.
-- Exception: PHP 7.4 MIGHT not be considered.
 
 ## composer.json
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -