### PR TITLE
Use git clone for starting with docker

### DIFF
--- a/src/guide/start/creating-project.md
+++ b/src/guide/start/creating-project.md
@@ -16,7 +16,15 @@ You can create a new project from a template using the [Composer](https://getcom
 composer create-project yiisoft/app your_project
 ```
 
-Docker users can run the following commands: 
+Docker users can run the following commands:
+
+```sh
+docker run --rm -it -v "$(pwd):/app" --user $(id -u):$(id -g) composer/composer create-project yiisoft/app your_project
+sudo chown -R $(id -u):$(id -g) your_project
+cd your_project
+```
+
+If you want development version instead of release one:
  
 ```sh
 git clone https://github.com/yiisoft/app.git --depth 1 your_project && \


### PR DESCRIPTION
1. It adds a way with `git clone`
2. It fixes permissions when using composer in Docker to create a project