### PR TITLE
Fix #416: Document route arguments in actions

### DIFF
--- a/src/guide/runtime/routing.md
+++ b/src/guide/runtime/routing.md
@@ -101,6 +101,39 @@ For handler action and callable typed parameters are automatically injected usin
 injection container passed to the route.
 
 Get current request and handler by type-hinting for `ServerRequestInterface` and `RequestHandlerInterface`.
+
+### Route arguments in actions
+
+Named route parameters are stored in `CurrentRoute`. To pass a route parameter to an action method parameter,
+use the `RouteArgument` attribute:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Router\HydratorAttribute\RouteArgument;
+use Yiisoft\Router\Route;
+
+return [
+    Route::get('/post/{id:\d+}')
+        ->action([PostController::class, 'view'])
+        ->name('post/view')
+];
+
+final readonly class PostController
+{
+    public function view(#[RouteArgument('id')] int $id): ResponseInterface
+    {
+        // $id contains the value from the {id} route parameter.
+    }
+}
+```
+
+For optional route parameters, provide a default value either in the route with `defaults()` or in the action method
+signature.
+
 You could add extra handlers to wrap primary one with `middleware()` method:
 
 ```php
@@ -267,7 +300,7 @@ If `RegExp` isn't specified, it means the parameter value should be a string wit
 You can't use capturing groups. For example `{lang:(en|de)}` isn't a valid placeholder, because `()` is
 a capturing group. Instead, you can use either `{lang:en|de}` or `{lang:(?:en|de)}`.
 
-On a route match router fills the associated request attributes with values matching the corresponding parts of the URL.
+On a route match router fills `CurrentRoute` arguments with values matching the corresponding parts of the URL.
 When you use the rule to create a URL, it will take the values of the provided parameters and insert them at the
 places where the parameters are declared.
 

--- a/src/guide/start/hello.md
+++ b/src/guide/start/hello.md
@@ -86,7 +86,7 @@ return [
 
 In the above, you map the `/say[/{message}]` pattern to `\App\Web\Echo\Action`. 
 For a request, the router creates an instance and calls the `__invoke()` method.
-The `{message}` part of the pattern writes anything specified in this place to the `message` request attribute.
+The `{message}` part of the pattern writes anything specified in this place to the `message` route argument.
 `[]` marks this part of the pattern as optional. 
 
 You also give a `echo/say` name to this route to be able to generate URLs pointing to it.

--- a/src/guide/structure/action.md
+++ b/src/guide/structure/action.md
@@ -58,6 +58,7 @@ The class itself would look like the following:
 ```php
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
+use Yiisoft\Router\HydratorAttribute\RouteArgument;
 
 final readonly class PostController
 {
@@ -67,14 +68,22 @@ final readonly class PostController
     }
     
     
-    public function actionView(ServerRequestInterface $request): ResponseInterface
+    public function actionView(
+        ServerRequestInterface $request,
+        #[RouteArgument('id')]
+        int $id,
+    ): ResponseInterface
     {
-        // render a single post      
+        // render a single post by $id
     }
 }
 ```
 
 We usually call such a class "controller."
+
+The `{id}` part of the `/post/view/{id:\d+}` route is a named route parameter. Route parameters are available from
+`Yiisoft\Router\CurrentRoute`. To receive one as an action argument, add the `RouteArgument` attribute to the
+corresponding parameter. The attribute name should match the route parameter name.
 
 ## Autowiring
 
@@ -110,4 +119,3 @@ final readonly class PostController
 
 In the above example `PostRepository` is injected automatically via constructor. That means it is available in every
 action. Logger is injected into `index` action only. 
-


### PR DESCRIPTION
Closes #416

- Explain how named route parameters are passed to action arguments with RouteArgument.
- Add the same concept to the Actions page example.
- Replace stale request attribute wording in the Hello tutorial with route argument wording.