### PR TITLE
Fix #175: Document line length convention

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+max_line_length = 120
 trim_trailing_whitespace = true
 
 [*.md]

--- a/src/internals/010-code-style.md
+++ b/src/internals/010-code-style.md
@@ -31,6 +31,19 @@ Class comment should describe the purpose of the class.
 
 ## Formatting
 
+### Line length
+
+The maximum line length is 120 characters.
+
+When a function or method call exceeds the limit, split arguments into separate lines:
+
+```php
+$this->assertSame(
+    ['' => ['Value must be no less than 5.']],
+    $result->getErrorMessagesIndexedByPath(),
+);
+```
+
 ### No alignment
 
 Property, variable and constant value assignments shouldn't be aligned.
@@ -184,4 +197,3 @@ use function is_iterable;
 - [Namespaces](004-namespaces.md)
 - [Exceptions](007-exceptions.md)
 - [Interfaces](008-interfaces.md)
-


### PR DESCRIPTION
Closes #175

- Add max_line_length = 120 to EditorConfig.
- Document the 120-character limit in the internals code-style guide.
- Show an example of splitting long method-call arguments.