### PR TITLE
Fix #176: Document using PER coding style

### DIFF
--- a/src/internals/010-code-style.md
+++ b/src/internals/010-code-style.md
@@ -57,6 +57,27 @@ final class X
 }
 ```
 
+### Trailing commas
+
+Use a trailing comma when arguments, parameters, or array elements are split into multiple lines:
+
+```php
+$this->assertSame(
+    ['' => ['Value must be no less than 5.']],
+    $result->getErrorMessagesIndexedByPath(),
+);
+```
+
+The same applies to constructor calls and function or method declarations:
+
+```php
+public function __construct(
+    private string $name,
+    private int $value,
+) {
+}
+```
+
 ### Chain calls
 
 Chained calls should be formatted for better readability.
@@ -184,4 +205,3 @@ use function is_iterable;
 - [Namespaces](004-namespaces.md)
 - [Exceptions](007-exceptions.md)
 - [Interfaces](008-interfaces.md)
-

--- a/src/internals/010-code-style.md
+++ b/src/internals/010-code-style.md
@@ -1,7 +1,7 @@
 # 010 — Code style
 
-Code formatting used in Yii 3 packages is based on [PSR-1](https://www.php-fig.org/psr/psr-1/) and
-[PSR-12](https://www.php-fig.org/psr/psr-12/) with extra rules added on top of it.
+Code formatting used in Yii 3 packages is based on [PER Coding Style 3.0](https://www.php-fig.org/per/coding-style/)
+with extra rules added on top of it.
 
 ## Names
 
@@ -54,27 +54,6 @@ final class X
         $test = 123;
         $anotherTest = 123;
     }
-}
-```
-
-### Trailing commas
-
-Use a trailing comma when arguments, parameters, or array elements are split into multiple lines:
-
-```php
-$this->assertSame(
-    ['' => ['Value must be no less than 5.']],
-    $result->getErrorMessagesIndexedByPath(),
-);
-```
-
-The same applies to constructor calls and function or method declarations:
-
-```php
-public function __construct(
-    private string $name,
-    private int $value,
-) {
 }
 ```
 


### PR DESCRIPTION
Closes #176

- Add a trailing comma convention to the internals code-style guide.
- Cover multiline arguments, parameters, arrays, constructor calls, and method declarations.