### PR TITLE
Fix #279: Remove version fields from bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,14 @@
+name: Bug Report
+description: Let us know about a problem
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > WARNING: DON'T CREATE SECURITY ISSUE here, use [this form](https://www.yiiframework.com/security) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a detailed description of the issue. Include all relevant information to help us understand and reproduce the problem.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,10 @@
+name: Feature request
+description: Suggest an idea for improvement
+body:
+  - type: textarea
+    attributes:
+      label: Proposed new feature or change
+      description: |
+        Describe the feature and explain why it's needed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation-issue.yml
@@ -1,0 +1,10 @@
+name: Documentation Issue
+description: Report documentation issues or suggest improvements
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue and what you expected to find.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Yii Community
+    url: https://www.yiiframework.com/community
+    about: Join our friendly and helpful Yii community!


### PR DESCRIPTION
Closes #279.

Adds repository-local issue templates and removes the package version and PHP version fields from the bug report form. The other inherited issue templates are included locally because GitHub stops using the organization default issue template folder when a repository defines its own ISSUE_TEMPLATE directory.