### PR TITLE
Update configuration reference in Yii tutorial

### DIFF
--- a/src/guide/tutorial/using-yii-with-frankenphp.md
+++ b/src/guide/tutorial/using-yii-with-frankenphp.md
@@ -214,7 +214,7 @@ For the general implications of long-running workers, see [Using Yii with event 
 ## Additional configuration
 
 `FrankenPHPApplicationRunner` is configured by default for Yii application templates and follows the
-[dependency container configuration](https://yiisoft.github.io/docs/guide/concept/configuration.html#container-configuration) concept.
+[dependency container configuration](../../guide/concept/configuration.html#container-configuration) concept.
 
 The constructor allows overriding the default bootstrap, events, DI, params, and error-handler configuration.
 You can also provide a custom config instance with `withConfig()` and a custom container with `withContainer()`.

--- a/src/guide/tutorial/using-yii-with-frankenphp.md
+++ b/src/guide/tutorial/using-yii-with-frankenphp.md
@@ -214,7 +214,7 @@ For the general implications of long-running workers, see [Using Yii with event 
 ## Additional configuration
 
 `FrankenPHPApplicationRunner` is configured by default for Yii application templates and follows the
-[config groups convention](https://github.com/yiisoft/docs/blob/master/022-config-groups.md).
+[dependency container configuration](https://yiisoft.github.io/docs/guide/concept/configuration.html#container-configuration) concept.
 
 The constructor allows overriding the default bootstrap, events, DI, params, and error-handler configuration.
 You can also provide a custom config instance with `withConfig()` and a custom container with `withContainer()`.


### PR DESCRIPTION
Updated documentation to reference dependency container configuration instead of config groups convention.
