### PR TITLE
Fix #395: Add htmx partial reloads recipe

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -188,6 +188,7 @@ export default {
                             items: [
                                 {text: 'Preface', link: '/cookbook/preface'},
                                 {text: 'Making HTTP Requests', link: '/cookbook/making-http-requests'},
+                                {text: 'Using htmx for Partial Page Reloads', link: '/cookbook/using-htmx-for-partial-reloads'},
                                 {text: 'Disabling CSRF Protection', link: '/cookbook/disabling-csrf-protection'},
                                 {text: 'Sentry Integration', link: '/cookbook/sentry-integration'}
                             ]

--- a/src/cookbook/index.md
+++ b/src/cookbook/index.md
@@ -14,6 +14,7 @@ This book conforms to the [Terms of Yii Documentation](https://www.yiiframework.
 
 - [Preface](preface.md)
 - [Making HTTP requests](making-http-requests.md)
+- [Using htmx for partial page reloads](using-htmx-for-partial-reloads.md)
 - [Disabling CSRF protection](disabling-csrf-protection.md)
 - [Sentry integration](sentry-integration.md)
 - [Working on Windows](working-on-windows.md)

--- a/src/cookbook/using-htmx-for-partial-reloads.md
+++ b/src/cookbook/using-htmx-for-partial-reloads.md
@@ -4,9 +4,9 @@
 application, this works well for grids: sorting, filtering, and pagination can update only the grid while the rest of
 the page stays in place.
 
-This recipe shows the pattern used by the
-[Yii demo diary application](https://github.com/yiisoft/demo-diary/pull/54): load htmx, create the grid as a widget,
-add htmx attributes to the grid controls, and return only the widget HTML for htmx requests.
+This recipe uses `GridView` as an example because it has links and forms that naturally benefit from partial reloads.
+The same pattern works for any widget or page fragment: render the fragment separately, add htmx attributes to the
+controls that should refresh it, and return only that fragment for htmx requests.
 
 ## Install GridView
 
@@ -18,7 +18,7 @@ composer require yiisoft/yii-dataview
 
 ## Load htmx
 
-Create `src/Web/Shared/Layout/Main/HtmxAsset.php`:
+The simplest setup is loading htmx from a CDN. Create `src/Web/Shared/Layout/Main/HtmxAsset.php`:
 
 ```php
 <?php
@@ -44,8 +44,31 @@ final class HtmxAsset extends AssetBundle
 }
 ```
 
-When updating the htmx version, update the URL and `integrity` value together. To serve htmx locally, download
-`htmx.min.js` and register it from an application asset directory.
+When updating the htmx version, update the URL and `integrity` value together.
+
+For production applications, consider serving htmx from your application assets to avoid depending on a third-party CDN.
+Download `htmx.min.js` into `assets/main/js/htmx.min.js` and use a local asset bundle:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Shared\Layout\Main;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class HtmxAsset extends AssetBundle
+{
+    public ?string $basePath = '@assets/main';
+    public ?string $baseUrl = '@assetsUrl/main';
+    public ?string $sourcePath = '@assetsSource/main';
+
+    public array $js = [
+        'js/htmx.min.js',
+    ];
+}
+```
 
 Add the bundle to the main layout asset:
 
@@ -344,7 +367,7 @@ should be replaced.
 In the browser developer tools, the htmx requests should include the `HX-Request` header. Their responses should contain
 only the grid container.
 
-Use the same pattern for other page fragments:
+Use the same pattern for other widgets or page fragments:
 
 1. Put the reloadable HTML into a widget or another small renderer.
 2. Add htmx attributes to the links and forms that should refresh it.

--- a/src/cookbook/using-htmx-for-partial-reloads.md
+++ b/src/cookbook/using-htmx-for-partial-reloads.md
@@ -1,0 +1,298 @@
+# Using htmx for partial page reloads
+
+[htmx](https://htmx.org/) lets links and forms request HTML fragments and swap them into the current page. In a Yii
+application this works well for grids: sorting, filtering, and pagination can update only the grid while the rest of the
+page stays in place.
+
+This recipe shows the pattern used by the
+[Yii demo diary application](https://github.com/yiisoft/demo-diary/pull/54): load htmx, extract the grid into a widget,
+add htmx attributes to the grid controls, and return only the widget HTML for htmx requests.
+
+## Load htmx
+
+Create an asset bundle for htmx:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Site\Layout;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class HtmxAsset extends AssetBundle
+{
+    public bool $cdn = true;
+
+    public array $js = [
+        'https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js',
+    ];
+
+    public array $jsOptions = [
+        'integrity' => 'sha384-H5SrcfygHmAuTDZphMHqBJLc3FhssKjG7w/CeCpFReSfwBWDTKpkzPP8c+cLsK+V',
+        'crossorigin' => 'anonymous',
+    ];
+}
+```
+
+When updating the htmx version, update the URL and `integrity` value together. If the application doesn't use a CDN,
+download `htmx.min.js` and register it from an application asset directory instead.
+
+Add the bundle to the main layout asset:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Site\Layout;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class MainAsset extends AssetBundle
+{
+    public ?string $basePath = '@assets/main';
+    public ?string $baseUrl = '@assetsUrl/main';
+    public ?string $sourcePath = '@assetsSource/main';
+
+    public array $css = [
+        'site.css',
+    ];
+
+    public array $depends = [
+        BootstrapAsset::class,
+        HtmxAsset::class,
+    ];
+}
+```
+
+## Extract the reloadable part
+
+Put the grid into its own widget. The widget must render the complete HTML fragment that htmx will replace.
+
+The example below uses `yiisoft/yii-dataview` `GridView`. Replace `UserDataReader`, `User`, and the columns with the
+reader and columns from your application.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\UseCase\Users\List;
+
+use App\Shared\UrlGenerator;
+use App\UseCase\Users\List\DataReader\User;
+use App\UseCase\Users\List\DataReader\UserDataReader;
+use Yiisoft\Data\Paginator\PaginatorInterface;
+use Yiisoft\Html\Html;
+use Yiisoft\Widget\Widget;
+use Yiisoft\Yii\DataView\GridView\Column\ActionButton;
+use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
+use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
+use Yiisoft\Yii\DataView\GridView\GridView;
+use Yiisoft\Yii\DataView\Pagination\OffsetPagination;
+use Yiisoft\Yii\DataView\Pagination\PaginationWidgetInterface;
+
+final class UsersList extends Widget
+{
+    public function __construct(
+        private readonly UrlGenerator $urlGenerator,
+        private readonly UserDataReader $userDataReader,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $htmxLoadAttributes = [
+            'hx-indicator' => '#UsersGridView',
+            'hx-target' => '#UsersGridView',
+            'hx-replace-url' => 'true',
+            'hx-swap' => 'outerHTML',
+        ];
+
+        /** @var PaginationWidgetInterface<PaginatorInterface> */
+        $pagination = OffsetPagination::widget()->addLinkAttributes([
+            'hx-boost' => 'true',
+            ...$htmxLoadAttributes,
+        ]);
+
+        return GridView::widget()
+            ->containerAttributes([
+                'id' => 'UsersGridView',
+                'class' => 'mt-4 position-relative',
+            ])
+            ->dataReader($this->userDataReader)
+            ->sortableLinkAttributes([
+                'hx-boost' => 'true',
+                ...$htmxLoadAttributes,
+            ])
+            ->filterFormAttributes([
+                'hx-boost' => 'true',
+                ...$htmxLoadAttributes,
+            ])
+            ->paginationWidget($pagination)
+            ->columns(
+                new DataColumn(
+                    'id',
+                    header: 'ID',
+                    filter: true,
+                ),
+                new DataColumn(
+                    'login',
+                    filter: true,
+                ),
+                new DataColumn(
+                    'name',
+                    filter: true,
+                ),
+                new DataColumn(
+                    'status',
+                    content: static fn(User $user) => $user->status->label(),
+                ),
+                new ActionColumn(
+                    before: '<div class="btn-group">',
+                    after: '</div>',
+                    buttons: [
+                        new ActionButton(
+                            Html::i()->class('bi bi-pencil'),
+                            fn(User $user) => $this->urlGenerator->generate('user/update', ['id' => $user->id]),
+                            title: 'Update',
+                        ),
+                    ],
+                ),
+            )
+            ->render();
+    }
+}
+```
+
+The important part is the shared `$htmxLoadAttributes` array:
+
+- `hx-boost="true"` makes the grid links and filter form send htmx requests.
+- `hx-target="#UsersGridView"` tells htmx which element to replace.
+- `hx-swap="outerHTML"` replaces the whole grid container with the response.
+- `hx-replace-url="true"` keeps the browser URL in sync with the current sort, filter, and page.
+- `hx-indicator="#UsersGridView"` marks the grid as the loading indicator element while the request is active.
+
+The target selector and the container `id` must match. In this example, both use `UsersGridView`.
+
+## Render the widget in the full page
+
+In the full page template, render regular page content and put the reloadable widget where the grid belongs:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Presentation\Site\Layout\Breadcrumbs\Breadcrumb;
+use App\Shared\UrlGenerator;
+use App\UseCase\Users\List\UsersList;
+use Yiisoft\Html\Html;
+use Yiisoft\Html\NoEncode;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var UrlGenerator $urlGenerator
+ */
+
+$this->setTitle('Users');
+$this->addToParameter('breadcrumbs', new Breadcrumb('Users'));
+?>
+<div class="d-flex justify-content-between align-items-center">
+    <h1>Users</h1>
+    <?= Html::a(
+        NoEncode::string('<i class="bi bi-person-plus me-1"></i> Create user'),
+        $urlGenerator->generate('user/create'),
+        ['class' => 'btn btn-outline-primary btn-sm'],
+    ) ?>
+</div>
+<?= UsersList::widget() ?>
+```
+
+The first page load still returns a complete page with layout, title, breadcrumbs, and actions.
+
+## Return partial HTML for htmx requests
+
+htmx sends the `HX-Request` header with its requests.
+
+In the action, return only the widget when the header is present:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\UseCase\Users\List;
+
+use App\Presentation\Site\ResponseFactory\ResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class Action
+{
+    public function __construct(
+        private ResponseFactory $responseFactory,
+    ) {
+    }
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = $request->getHeaderLine('HX-Request') === 'true'
+            ? $this->responseFactory->createHtmlResponse(UsersList::widget())
+            : $this->responseFactory->render(__DIR__ . '/template.php');
+
+        return $response->withAddedHeader('Vary', 'HX-Request');
+    }
+}
+```
+
+The `Vary` header matters when a browser, proxy, or CDN caches responses. The same URL can return a full page without
+`HX-Request` and a fragment with `HX-Request: true`, so caches must keep these responses separate.
+
+If your response factory doesn't have a method for raw HTML, add one with `HtmlResponseFactory`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Site\ResponseFactory;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\DataResponse\ResponseFactory\HtmlResponseFactory;
+use Yiisoft\Http\Status;
+
+final readonly class ResponseFactory
+{
+    public function __construct(
+        private HtmlResponseFactory $htmlResponseFactory,
+        // Other dependencies.
+    ) {
+    }
+
+    public function createHtmlResponse(
+        mixed $data = null,
+        int $code = Status::OK,
+        string $reasonPhrase = '',
+    ): ResponseInterface {
+        return $this->htmlResponseFactory->createResponse($data, $code, $reasonPhrase);
+    }
+}
+```
+
+## Try it
+
+Open the list page and use sorting, filtering, or pagination. The browser URL should change, and only the grid HTML
+should be replaced.
+
+In the browser developer tools, the htmx requests should include the `HX-Request` header. Their responses should contain
+only the grid container.
+
+Use the same pattern for other page fragments:
+
+1. Put the reloadable HTML into a widget or another small renderer.
+2. Add htmx attributes to the links and forms that should refresh it.
+3. Return the fragment for htmx requests and the full page for regular requests.

--- a/src/cookbook/using-htmx-for-partial-reloads.md
+++ b/src/cookbook/using-htmx-for-partial-reloads.md
@@ -1,23 +1,31 @@
 # Using htmx for partial page reloads
 
 [htmx](https://htmx.org/) lets links and forms request HTML fragments and swap them into the current page. In a Yii
-application this works well for grids: sorting, filtering, and pagination can update only the grid while the rest of the
-page stays in place.
+application, this works well for grids: sorting, filtering, and pagination can update only the grid while the rest of
+the page stays in place.
 
 This recipe shows the pattern used by the
-[Yii demo diary application](https://github.com/yiisoft/demo-diary/pull/54): load htmx, extract the grid into a widget,
+[Yii demo diary application](https://github.com/yiisoft/demo-diary/pull/54): load htmx, create the grid as a widget,
 add htmx attributes to the grid controls, and return only the widget HTML for htmx requests.
+
+## Install GridView
+
+Install the data view package if the application doesn't use it yet:
+
+```shell
+composer require yiisoft/yii-dataview
+```
 
 ## Load htmx
 
-Create an asset bundle for htmx:
+Create `src/Web/Shared/Layout/Main/HtmxAsset.php`:
 
 ```php
 <?php
 
 declare(strict_types=1);
 
-namespace App\Presentation\Site\Layout;
+namespace App\Web\Shared\Layout\Main;
 
 use Yiisoft\Assets\AssetBundle;
 
@@ -36,8 +44,8 @@ final class HtmxAsset extends AssetBundle
 }
 ```
 
-When updating the htmx version, update the URL and `integrity` value together. If the application doesn't use a CDN,
-download `htmx.min.js` and register it from an application asset directory instead.
+When updating the htmx version, update the URL and `integrity` value together. To serve htmx locally, download
+`htmx.min.js` and register it from an application asset directory.
 
 Add the bundle to the main layout asset:
 
@@ -46,7 +54,7 @@ Add the bundle to the main layout asset:
 
 declare(strict_types=1);
 
-namespace App\Presentation\Site\Layout;
+namespace App\Web\Shared\Layout\Main;
 
 use Yiisoft\Assets\AssetBundle;
 
@@ -67,41 +75,163 @@ final class MainAsset extends AssetBundle
 }
 ```
 
-## Extract the reloadable part
+## Create the reloadable part
 
-Put the grid into its own widget. The widget must render the complete HTML fragment that htmx will replace.
+Start with a regular page that renders a grid. In a clean `yiisoft/app` project, this means adding an action, a view
+template, and a widget that renders the grid. The first version doesn't need htmx. It should work as a normal full page.
 
-The example below uses `yiisoft/yii-dataview` `GridView`. Replace `UserDataReader`, `User`, and the columns with the
-reader and columns from your application.
+Create `src/Web/Users/Index/UsersGrid.php`:
 
 ```php
 <?php
 
 declare(strict_types=1);
 
-namespace App\UseCase\Users\List;
+namespace App\Web\Users\Index;
 
-use App\Shared\UrlGenerator;
-use App\UseCase\Users\List\DataReader\User;
-use App\UseCase\Users\List\DataReader\UserDataReader;
 use Yiisoft\Data\Paginator\PaginatorInterface;
-use Yiisoft\Html\Html;
+use Yiisoft\Data\Reader\Iterable\IterableDataReader;
 use Yiisoft\Widget\Widget;
-use Yiisoft\Yii\DataView\GridView\Column\ActionButton;
-use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
-use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
+use Yiisoft\Yii\DataView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\GridView;
 use Yiisoft\Yii\DataView\Pagination\OffsetPagination;
 use Yiisoft\Yii\DataView\Pagination\PaginationWidgetInterface;
 
-final class UsersList extends Widget
+final class UsersGrid extends Widget
+{
+    public function render(): string
+    {
+        /** @var PaginationWidgetInterface<PaginatorInterface> */
+        $pagination = OffsetPagination::widget();
+
+        return GridView::widget()
+            ->containerAttributes([
+                'id' => 'UsersGridView',
+                'class' => 'mt-4 position-relative',
+            ])
+            ->dataReader($this->dataReader())
+            ->pageSizeConstraint(5)
+            ->paginationWidget($pagination)
+            ->columns(
+                new DataColumn('id', header: 'ID', filter: true),
+                new DataColumn('login', header: 'Login', filter: true),
+                new DataColumn('name', header: 'Name', filter: true),
+                new DataColumn('status', header: 'Status', filter: true),
+            )
+            ->render();
+    }
+
+    private function dataReader(): IterableDataReader
+    {
+        return new IterableDataReader([
+            ['id' => 1, 'login' => 'admin', 'name' => 'Alice Adams', 'status' => 'Active'],
+            ['id' => 2, 'login' => 'editor', 'name' => 'Eve Editor', 'status' => 'Active'],
+            ['id' => 3, 'login' => 'author', 'name' => 'Arthur Author', 'status' => 'Active'],
+            ['id' => 4, 'login' => 'reviewer', 'name' => 'Rita Reviewer', 'status' => 'Inactive'],
+            ['id' => 5, 'login' => 'support', 'name' => 'Sam Support', 'status' => 'Active'],
+            ['id' => 6, 'login' => 'guest', 'name' => 'Grace Guest', 'status' => 'Inactive'],
+        ]);
+    }
+}
+```
+
+For a real application, replace `dataReader()` with a reader backed by a database query or repository. Keep the widget
+responsible for rendering the grid fragment.
+
+Create `src/Web/Users/Index/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Web\Users\Index\UsersGrid;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ */
+
+$this->setTitle('Users');
+?>
+<h1>Users</h1>
+
+<?= UsersGrid::widget() ?>
+```
+
+Create `src/Web/Users/Index/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Users\Index;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
+
+final readonly class Action
 {
     public function __construct(
-        private readonly UrlGenerator $urlGenerator,
-        private readonly UserDataReader $userDataReader,
+        private WebViewRenderer $viewRenderer,
     ) {
     }
 
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template');
+    }
+}
+```
+
+Add the action to `config/common/routes.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Web;
+use Yiisoft\Router\Group;
+use Yiisoft\Router\Route;
+
+return [
+    Group::create()
+        ->routes(
+            Route::get('/')
+                ->action(Web\HomePage\Action::class)
+                ->name('home'),
+            Route::get('/users')
+                ->action(Web\Users\Index\Action::class)
+                ->name('users/index'),
+        ),
+];
+```
+
+Open `/users` and make sure sorting, filtering, and pagination work with full page reloads first.
+
+## Add htmx attributes to the grid
+
+Now update `UsersGrid` so the grid controls request a fragment and swap it into `#UsersGridView`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Users\Index;
+
+use Yiisoft\Data\Paginator\PaginatorInterface;
+use Yiisoft\Data\Reader\Iterable\IterableDataReader;
+use Yiisoft\Widget\Widget;
+use Yiisoft\Yii\DataView\Column\DataColumn;
+use Yiisoft\Yii\DataView\GridView\GridView;
+use Yiisoft\Yii\DataView\Pagination\OffsetPagination;
+use Yiisoft\Yii\DataView\Pagination\PaginationWidgetInterface;
+
+final class UsersGrid extends Widget
+{
     public function render(): string
     {
         $htmxLoadAttributes = [
@@ -122,7 +252,8 @@ final class UsersList extends Widget
                 'id' => 'UsersGridView',
                 'class' => 'mt-4 position-relative',
             ])
-            ->dataReader($this->userDataReader)
+            ->dataReader($this->dataReader())
+            ->pageSizeConstraint(5)
             ->sortableLinkAttributes([
                 'hx-boost' => 'true',
                 ...$htmxLoadAttributes,
@@ -133,36 +264,24 @@ final class UsersList extends Widget
             ])
             ->paginationWidget($pagination)
             ->columns(
-                new DataColumn(
-                    'id',
-                    header: 'ID',
-                    filter: true,
-                ),
-                new DataColumn(
-                    'login',
-                    filter: true,
-                ),
-                new DataColumn(
-                    'name',
-                    filter: true,
-                ),
-                new DataColumn(
-                    'status',
-                    content: static fn(User $user) => $user->status->label(),
-                ),
-                new ActionColumn(
-                    before: '<div class="btn-group">',
-                    after: '</div>',
-                    buttons: [
-                        new ActionButton(
-                            Html::i()->class('bi bi-pencil'),
-                            fn(User $user) => $this->urlGenerator->generate('user/update', ['id' => $user->id]),
-                            title: 'Update',
-                        ),
-                    ],
-                ),
+                new DataColumn('id', header: 'ID', filter: true),
+                new DataColumn('login', header: 'Login', filter: true),
+                new DataColumn('name', header: 'Name', filter: true),
+                new DataColumn('status', header: 'Status', filter: true),
             )
             ->render();
+    }
+
+    private function dataReader(): IterableDataReader
+    {
+        return new IterableDataReader([
+            ['id' => 1, 'login' => 'admin', 'name' => 'Alice Adams', 'status' => 'Active'],
+            ['id' => 2, 'login' => 'editor', 'name' => 'Eve Editor', 'status' => 'Active'],
+            ['id' => 3, 'login' => 'author', 'name' => 'Arthur Author', 'status' => 'Active'],
+            ['id' => 4, 'login' => 'reviewer', 'name' => 'Rita Reviewer', 'status' => 'Inactive'],
+            ['id' => 5, 'login' => 'support', 'name' => 'Sam Support', 'status' => 'Active'],
+            ['id' => 6, 'login' => 'guest', 'name' => 'Grace Guest', 'status' => 'Inactive'],
+        ]);
     }
 }
 ```
@@ -177,43 +296,6 @@ The important part is the shared `$htmxLoadAttributes` array:
 
 The target selector and the container `id` must match. In this example, both use `UsersGridView`.
 
-## Render the widget in the full page
-
-In the full page template, render regular page content and put the reloadable widget where the grid belongs:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Presentation\Site\Layout\Breadcrumbs\Breadcrumb;
-use App\Shared\UrlGenerator;
-use App\UseCase\Users\List\UsersList;
-use Yiisoft\Html\Html;
-use Yiisoft\Html\NoEncode;
-use Yiisoft\View\WebView;
-
-/**
- * @var WebView $this
- * @var UrlGenerator $urlGenerator
- */
-
-$this->setTitle('Users');
-$this->addToParameter('breadcrumbs', new Breadcrumb('Users'));
-?>
-<div class="d-flex justify-content-between align-items-center">
-    <h1>Users</h1>
-    <?= Html::a(
-        NoEncode::string('<i class="bi bi-person-plus me-1"></i> Create user'),
-        $urlGenerator->generate('user/create'),
-        ['class' => 'btn btn-outline-primary btn-sm'],
-    ) ?>
-</div>
-<?= UsersList::widget() ?>
-```
-
-The first page load still returns a complete page with layout, title, breadcrumbs, and actions.
-
 ## Return partial HTML for htmx requests
 
 htmx sends the `HX-Request` header with its requests.
@@ -225,24 +307,26 @@ In the action, return only the widget when the header is present:
 
 declare(strict_types=1);
 
-namespace App\UseCase\Users\List;
+namespace App\Web\Users\Index;
 
-use App\Presentation\Site\ResponseFactory\ResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Yiisoft\DataResponse\ResponseFactory\HtmlResponseFactory;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
 
 final readonly class Action
 {
     public function __construct(
-        private ResponseFactory $responseFactory,
+        private WebViewRenderer $viewRenderer,
+        private HtmlResponseFactory $htmlResponseFactory,
     ) {
     }
 
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         $response = $request->getHeaderLine('HX-Request') === 'true'
-            ? $this->responseFactory->createHtmlResponse(UsersList::widget())
-            : $this->responseFactory->render(__DIR__ . '/template.php');
+            ? $this->htmlResponseFactory->createResponse(UsersGrid::widget())
+            : $this->viewRenderer->render(__DIR__ . '/template');
 
         return $response->withAddedHeader('Vary', 'HX-Request');
     }
@@ -251,37 +335,6 @@ final readonly class Action
 
 The `Vary` header matters when a browser, proxy, or CDN caches responses. The same URL can return a full page without
 `HX-Request` and a fragment with `HX-Request: true`, so caches must keep these responses separate.
-
-If your response factory doesn't have a method for raw HTML, add one with `HtmlResponseFactory`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Presentation\Site\ResponseFactory;
-
-use Psr\Http\Message\ResponseInterface;
-use Yiisoft\DataResponse\ResponseFactory\HtmlResponseFactory;
-use Yiisoft\Http\Status;
-
-final readonly class ResponseFactory
-{
-    public function __construct(
-        private HtmlResponseFactory $htmlResponseFactory,
-        // Other dependencies.
-    ) {
-    }
-
-    public function createHtmlResponse(
-        mixed $data = null,
-        int $code = Status::OK,
-        string $reasonPhrase = '',
-    ): ResponseInterface {
-        return $this->htmlResponseFactory->createResponse($data, $code, $reasonPhrase);
-    }
-}
-```
 
 ## Try it
 


### PR DESCRIPTION
Adds a cookbook tutorial for using htmx to reload a GridView fragment without a full page reload.\n\nThe recipe is based on the linked demo-diary implementation from issue #395 and covers:\n\n- loading htmx through an asset bundle;\n- extracting the GridView into a widget;\n- adding htmx attributes to sort, filter, and pagination controls;\n- returning partial HTML for htmx requests;\n- updating the cookbook TOC and VitePress menu.\n\nFixes #395