### PR TITLE
Add internationalization tutorial

### DIFF
--- a/_translations/po/es/guide_index.md.po
+++ b/_translations/po/es/guide_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -593,7 +593,7 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
+msgid "[Internationalization](tutorial/i18n.md)"
 msgstr ""
 
 #. type: Title ##

--- a/_translations/po/es/guide_tutorial_i18n.md.po
+++ b/_translations/po/es/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -596,29 +596,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr ""
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/es/guide_tutorial_i18n.md.po
+++ b/_translations/po/es/guide_tutorial_i18n.md.po
@@ -1,0 +1,762 @@
+# Spanish translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: 2026-05-09 11:15+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Introduction +"
+msgid "Internationalization"
+msgstr "Introducción"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "translated application messages;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "[Validating input](https://github.com/yiisoft/validator/blob/master/docs/guide/en/README.md) +"
+msgid "This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project."
+msgstr "[Validar Datos](https://github.com/yiisoft/validator/blob/master/docs/guide/en/README.md)"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Install packages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Introduction +"
+msgid "composer yii-config-rebuild\n"
+msgstr "Introducción"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Configure application locale"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The application template keeps basic application settings in `config/common/application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "You can define an alias via application's `config/params.php`:"
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr "Puedes definir un alias mediante la aplicación en `config/params.php`:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current locale. `defaultCategory` is the category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Configure message storage"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes extracted messages back to the same directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Translate messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for a response.  For the default home page action, update `src/Web/HomePage/Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid ""
+#| "use Psr\\EventDispatcher\\EventDispatcherInterface;\n"
+#| "\n"
+#| "final readonly class SignupService\n"
+#| "{\n"
+#| "    public function __construct(\n"
+#| "        private EventDispatcherInterface $eventDispatcher\n"
+#| "    )\n"
+#| "    {\n"
+#| "    }\n"
+#| "\n"
+#| "    public function signup(SignupForm $form)\n"
+#| "    {\n"
+#| "        // handle signup\n"
+#| "\n"
+#| "        $event = new UserSignedUp($form);\n"
+#| "        $this->eventDispatcher->dispatch($event);\n"
+#| "    }\n"
+#| "}\n"
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+"use Psr\\EventDispatcher\\EventDispatcherInterface;\n"
+"\n"
+"final readonly class SignupService\n"
+"{\n"
+"    public function __construct(\n"
+"        private EventDispatcherInterface $eventDispatcher\n"
+"    )\n"
+"    {\n"
+"    }\n"
+"\n"
+"    public function signup(SignupForm $form)\n"
+"    {\n"
+"        // handle signup\n"
+"\n"
+"        $event = new UserSignedUp($form);\n"
+"        $this->eventDispatcher->dispatch($event);\n"
+"    }\n"
+"}\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Escape translated text before output. Store trusted HTML separately or render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.  The example below uses the `lang` query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Register the middleware in `config/common/routes.php` or in the route group that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use message translation for labels, headings, buttons, validation messages, and short paragraphs.  Use localized view files when a page needs different markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when `src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/template.php`"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "You can set the locale for a single render call:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Extract messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure the extractor so it can read existing messages and write new IDs to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After extraction, edit target language files and replace source IDs with translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Working with categories"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The default `app` category is enough for most application messages. Add categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Keep message IDs stable. Changing an ID creates a new translation task for every locale."
+msgstr ""

--- a/_translations/po/es/guide_tutorial_i18n.md.po
+++ b/_translations/po/es/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -596,7 +596,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/es/guide_tutorial_i18n.md.po
+++ b/_translations/po/es/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -25,7 +25,7 @@ msgstr "Introducción"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgid "Internationalization prepares an application for more than one locale. Localization is the locale-specific part: translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`."
 msgstr ""
 
 #. type: Plain text
@@ -92,18 +92,6 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
 msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, fuzzy, no-wrap
-#| msgid "Introduction +"
-msgid "composer yii-config-rebuild\n"
-msgstr "Introducción"
 
 #. type: Title ##
 #: ../src/guide/tutorial/i18n.md
@@ -632,6 +620,13 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
 msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Introduction +"
+msgid "composer yii-config-rebuild\n"
+msgstr "Introducción"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md

--- a/_translations/po/id/guide_index.md.po
+++ b/_translations/po/id/guide_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -602,7 +602,7 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
+msgid "[Internationalization](tutorial/i18n.md)"
 msgstr ""
 
 #. type: Title ##

--- a/_translations/po/id/guide_tutorial_i18n.md.po
+++ b/_translations/po/id/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -24,7 +24,7 @@ msgstr "Konfigurasi container"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgid "Internationalization prepares an application for more than one locale. Localization is the locale-specific part: translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`."
 msgstr ""
 
 #. type: Plain text
@@ -92,18 +92,6 @@ msgstr "composer require yiisoft/cache\n"
 #: ../src/guide/tutorial/i18n.md
 msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
 msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, fuzzy, no-wrap
-#| msgid "Container configuration"
-msgid "composer yii-config-rebuild\n"
-msgstr "Konfigurasi container"
 
 #. type: Title ##
 #: ../src/guide/tutorial/i18n.md
@@ -597,6 +585,13 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
 msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Container configuration"
+msgid "composer yii-config-rebuild\n"
+msgstr "Konfigurasi container"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md

--- a/_translations/po/id/guide_tutorial_i18n.md.po
+++ b/_translations/po/id/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -561,29 +561,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr ""
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/id/guide_tutorial_i18n.md.po
+++ b/_translations/po/id/guide_tutorial_i18n.md.po
@@ -1,0 +1,727 @@
+# Indonesian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: 2026-05-09 11:15+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Container configuration"
+msgid "Internationalization"
+msgstr "Konfigurasi container"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "translated application messages;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "To use cache, install [yiisoft/cache](https://github.com/yiisoft/cache) package:"
+msgid "This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project."
+msgstr "Untuk menggunakan cache, pasang paket [yiisoft/cache](https://github.com/yiisoft/cache):"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Install packages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr "composer require yiisoft/cache\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer require yiisoft/cache\n"
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr "composer require yiisoft/cache\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Container configuration"
+msgid "composer yii-config-rebuild\n"
+msgstr "Konfigurasi container"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Configuration"
+msgid "Configure application locale"
+msgstr "Konfigurasi"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The application template keeps basic application settings in `config/common/application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "You can define an alias via application's `config/params.php`:"
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr "Anda dapat mendefinisikan sebuah alias melalui `config/params.php` aplikasi:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current locale. `defaultCategory` is the category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Configuration"
+msgid "Configure message storage"
+msgstr "Konfigurasi"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes extracted messages back to the same directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Translate messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for a response.  For the default home page action, update `src/Web/HomePage/Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Escape translated text before output. Store trusted HTML separately or render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.  The example below uses the `lang` query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Register the middleware in `config/common/routes.php` or in the route group that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use message translation for labels, headings, buttons, validation messages, and short paragraphs.  Use localized view files when a page needs different markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when `src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/template.php`"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "You can set the locale for a single render call:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Extract messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure the extractor so it can read existing messages and write new IDs to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After extraction, edit target language files and replace source IDs with translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Working with categories"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The default `app` category is enough for most application messages. Add categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Keep message IDs stable. Changing an ID creates a new translation task for every locale."
+msgstr ""

--- a/_translations/po/id/guide_tutorial_i18n.md.po
+++ b/_translations/po/id/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -561,7 +561,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/it/guide_index.md.po
+++ b/_translations/po/it/guide_index.md.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: 2026-01-04 21:18+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -578,7 +578,9 @@ msgstr "[Applicazioni console](tutorial/console-applications.md)"
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
+#, fuzzy
+#| msgid "[Internationalization](tutorial/i18n.md) TODO"
+msgid "[Internationalization](tutorial/i18n.md)"
 msgstr "[Internazionalizzazione](tutorial/i18n.md) TODO"
 
 #. type: Title ##

--- a/_translations/po/it/guide_tutorial_i18n.md.po
+++ b/_translations/po/it/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -676,29 +676,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr ""
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/it/guide_tutorial_i18n.md.po
+++ b/_translations/po/it/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -676,7 +676,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/it/guide_tutorial_i18n.md.po
+++ b/_translations/po/it/guide_tutorial_i18n.md.po
@@ -1,0 +1,842 @@
+# Italian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: 2026-05-09 11:15+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Generating API documentation"
+msgid "Internationalization"
+msgstr "Generazione della documentazione API"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "translated application messages;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "[VarDumper](https://github.com/yiisoft/var-dumper)"
+msgid "This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project."
+msgstr "[VarDumper](https://github.com/yiisoft/var-dumper)"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Install packages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer create-project yiisoft/app your_project\n"
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr "composer create-project yiisoft/app your_project\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer create-project yiisoft/app your_project\n"
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr "composer create-project yiisoft/app your_project\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer yii-config-rebuild\n"
+msgstr "[Configurazione](concept/configuration.md)"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Configure application locale"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The application template keeps basic application settings in `config/common/application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current locale. `defaultCategory` is the category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "[Configuration](concept/configuration.md)"
+msgid "Configure message storage"
+msgstr "[Configurazione](concept/configuration.md)"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes extracted messages back to the same directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Translate messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for a response.  For the default home page action, update `src/Web/HomePage/Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid ""
+#| "<?php\n"
+#| "\n"
+#| "declare(strict_types=1);\n"
+#| "\n"
+#| "namespace App\\Web\\Echo;\n"
+#| "\n"
+#| "use Psr\\Http\\Message\\ResponseInterface;\n"
+#| "use Yiisoft\\Router\\HydratorAttribute\\RouteArgument;\n"
+#| "use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+#| "\n"
+#| "final readonly class Action\n"
+#| "{\n"
+#| "    public function __construct(\n"
+#| "        private ViewRenderer $viewRenderer,\n"
+#| "    ) {}\n"
+#| "\n"
+#| "    public function __invoke(\n"
+#| "        #[RouteArgument('message')]\n"
+#| "        string $message = 'Hello!'\n"
+#| "    ): ResponseInterface\n"
+#| "    {\n"
+#| "        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+#| "            'message' => $message,\n"
+#| "        ]);\n"
+#| "    }\n"
+#| "}\n"
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Echo;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Router\\HydratorAttribute\\RouteArgument;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(\n"
+"        #[RouteArgument('message')]\n"
+"        string $message = 'Hello!'\n"
+"    ): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'message' => $message,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Echo/Action.php`:"
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr "Crea `src/Web/Echo/Action.php`:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Escape translated text before output. Store trusted HTML separately or render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.  The example below uses the `lang` query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid ""
+#| "<?php\n"
+#| "\n"
+#| "declare(strict_types=1);\n"
+#| "\n"
+#| "namespace App\\Web\\Echo;\n"
+#| "\n"
+#| "use Psr\\Http\\Message\\ResponseFactoryInterface;\n"
+#| "use Psr\\Http\\Message\\ResponseInterface;\n"
+#| "use Yiisoft\\Html\\Html;\n"
+#| "use Yiisoft\\Router\\HydratorAttribute\\RouteArgument;\n"
+#| "\n"
+#| "final readonly class Action\n"
+#| "{\n"
+#| "    public function __construct(\n"
+#| "        private ResponseFactoryInterface $responseFactory,\n"
+#| "    ) {}\n"
+#| "\n"
+#| "    public function __invoke(\n"
+#| "        #[RouteArgument('message')]\n"
+#| "        string $message = 'Hello!'\n"
+#| "    ): ResponseInterface\n"
+#| "    {\n"
+#| "        $response = $this->responseFactory->createResponse();\n"
+#| "        $response->getBody()->write('The message is: ' . Html::encode($message));\n"
+#| "        return $response;\n"
+#| "    }\n"
+#| "}\n"
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Echo;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseFactoryInterface;\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Router\\HydratorAttribute\\RouteArgument;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ResponseFactoryInterface $responseFactory,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(\n"
+"        #[RouteArgument('message')]\n"
+"        string $message = 'Hello!'\n"
+"    ): ResponseInterface\n"
+"    {\n"
+"        $response = $this->responseFactory->createResponse();\n"
+"        $response->getBody()->write('The message is: ' . Html::encode($message));\n"
+"        return $response;\n"
+"    }\n"
+"}\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Register the middleware in `config/common/routes.php` or in the route group that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use message translation for labels, headings, buttons, validation messages, and short paragraphs.  Use localized view files when a page needs different markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when `src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Echo/Action.php`:"
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr "Crea `src/Web/Echo/Action.php`:"
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Echo/Action.php`:"
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr "Crea `src/Web/Echo/Action.php`:"
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Echo/Action.php`:"
+msgid "`src/Web/HomePage/template.php`"
+msgstr "Crea `src/Web/Echo/Action.php`:"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "You can set the locale for a single render call:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Extract messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure the extractor so it can read existing messages and write new IDs to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After extraction, edit target language files and replace source IDs with translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Working with databases"
+msgid "Working with categories"
+msgstr "Lavorare con i database"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The default `app` category is enough for most application messages. Add categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Keep message IDs stable. Changing an ID creates a new translation task for every locale."
+msgstr ""

--- a/_translations/po/it/guide_tutorial_i18n.md.po
+++ b/_translations/po/it/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -25,7 +25,7 @@ msgstr "Generazione della documentazione API"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgid "Internationalization prepares an application for more than one locale. Localization is the locale-specific part: translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`."
 msgstr ""
 
 #. type: Plain text
@@ -94,17 +94,6 @@ msgstr "composer create-project yiisoft/app your_project\n"
 #: ../src/guide/tutorial/i18n.md
 msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
 msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, fuzzy, no-wrap
-msgid "composer yii-config-rebuild\n"
-msgstr "[Configurazione](concept/configuration.md)"
 
 #. type: Title ##
 #: ../src/guide/tutorial/i18n.md
@@ -711,6 +700,12 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
 msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer yii-config-rebuild\n"
+msgstr "[Configurazione](concept/configuration.md)"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md

--- a/_translations/po/ru/guide_index.md.po
+++ b/_translations/po/ru/guide_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -571,8 +571,10 @@ msgstr "Разрешение псевдонимов <span id=\"resolving-aliases
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
-msgstr ""
+#, fuzzy
+#| msgid "Resolving aliases <span id=\"resolving-aliases\"></span>"
+msgid "[Internationalization](tutorial/i18n.md)"
+msgstr "Разрешение псевдонимов <span id=\"resolving-aliases\"></span>"
 
 #. type: Title ##
 #: ../src/guide/index.md

--- a/_translations/po/ru/guide_tutorial_i18n.md.po
+++ b/_translations/po/ru/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -25,7 +25,7 @@ msgstr "Интеграция с Sentry"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgid "Internationalization prepares an application for more than one locale. Localization is the locale-specific part: translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`."
 msgstr ""
 
 #. type: Plain text
@@ -94,17 +94,6 @@ msgstr "composer install yiisoft/security\n"
 #: ../src/guide/tutorial/i18n.md
 msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
 msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, fuzzy, no-wrap
-msgid "composer yii-config-rebuild\n"
-msgstr "Безопасная конфигурация сервера"
 
 #. type: Title ##
 #: ../src/guide/tutorial/i18n.md
@@ -635,6 +624,12 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
 msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer yii-config-rebuild\n"
+msgstr "Безопасная конфигурация сервера"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md

--- a/_translations/po/ru/guide_tutorial_i18n.md.po
+++ b/_translations/po/ru/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -598,31 +598,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-#, fuzzy
-#| msgid "Add the following to your php.ini:"
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr "Добавьте в свой php.ini следующее:"
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/ru/guide_tutorial_i18n.md.po
+++ b/_translations/po/ru/guide_tutorial_i18n.md.po
@@ -1,0 +1,766 @@
+# Russian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: 2026-05-09 11:15+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Sentry integration"
+msgid "Internationalization"
+msgstr "Интеграция с Sentry"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Configuring SSL peer validation"
+msgid "translated application messages;"
+msgstr "Настройка проверки SSL-сертификата"
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Install the package"
+msgid "Install packages"
+msgstr "Установка пакета"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr "composer install yiisoft/security\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer install yiisoft/security\n"
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr "composer install yiisoft/security\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+msgid "composer yii-config-rebuild\n"
+msgstr "Безопасная конфигурация сервера"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Configuring SSL peer validation"
+msgid "Configure application locale"
+msgstr "Настройка проверки SSL-сертификата"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The application template keeps basic application settings in `config/common/application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Add the following to your php.ini:"
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr "Добавьте в свой php.ini следующее:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current locale. `defaultCategory` is the category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Confirming data integrity"
+msgid "Configure message storage"
+msgstr "Проверка целостности данных"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now create `config/common/di/db-pgsql.php`:"
+msgid "Create `config/common/di/translator.php`:"
+msgstr "Теперь создайте файл `config/common/di/db-pgsql.php`:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes extracted messages back to the same directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Translate messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for a response.  For the default home page action, update `src/Web/HomePage/Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid ""
+#| "final class MyService implements MyServiceInterface\n"
+#| "{\n"
+#| "    public function __construct(int $amount)\n"
+#| "    {\n"
+#| "    }\n"
+#| "\n"
+#| "    public function setDiscount(int $discount): void\n"
+#| "    {\n"
+#| "    \n"
+#| "    }\n"
+#| "}\n"
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+"class MyService implements MyServiceInterface\n"
+"{\n"
+"    public function __construct(int $amount)\n"
+"    {\n"
+"    }\n"
+"\n"
+"    public function setDiscount(int $discount): void\n"
+"    {\n"
+"    \n"
+"    }\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now, a template in `src/Web/Page/edit.php`:"
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr "Теперь создайте шаблон в файле `src/Web/Page/edit.php`:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Escape translated text before output. Store trusted HTML separately or render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.  The example below uses the `lang` query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Register the middleware in `config/common/routes.php` or in the route group that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "<?= \\Yiisoft\\Html\\Html::encode($username) ?>\n"
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr "<?= \\Yiisoft\\Html\\Html::encode($username) ?>\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use message translation for labels, headings, buttons, validation messages, and short paragraphs.  Use localized view files when a page needs different markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when `src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr "Создайте файл `src/Web/Page/DeleteAction.php`:"
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr "Создайте файл `src/Web/Page/DeleteAction.php`:"
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/template.php`"
+msgstr "Создайте файл `src/Web/Page/DeleteAction.php`:"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "You can set the locale for a single render call:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Extract messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure the extractor so it can read existing messages and write new IDs to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now create `config/common/di/db-pgsql.php`:"
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr "Теперь создайте файл `config/common/di/db-pgsql.php`:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Add the following to your php.ini:"
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr "Добавьте в свой php.ini следующее:"
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After extraction, edit target language files and replace source IDs with translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Working with forms"
+msgid "Working with categories"
+msgstr "Работа с формами"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The default `app` category is enough for most application messages. Add categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Keep message IDs stable. Changing an ID creates a new translation task for every locale."
+msgstr ""

--- a/_translations/po/ru/guide_tutorial_i18n.md.po
+++ b/_translations/po/ru/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -598,7 +598,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/zh-CN/guide_index.md.po
+++ b/_translations/po/zh-CN/guide_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: 2026-01-08 08:54+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -576,7 +576,9 @@ msgstr "[控制台应用](tutorial/console-applications.md)"
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
+#, fuzzy
+#| msgid "[Internationalization](tutorial/i18n.md) TODO"
+msgid "[Internationalization](tutorial/i18n.md)"
 msgstr "[国际化](tutorial/i18n.md) TODO"
 
 #. type: Title ##

--- a/_translations/po/zh-CN/guide_tutorial_i18n.md.po
+++ b/_translations/po/zh-CN/guide_tutorial_i18n.md.po
@@ -1,0 +1,752 @@
+# Language zh-CN translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: 2026-05-09 11:15+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh-CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Transactional migrations"
+msgid "Internationalization"
+msgstr "事务性迁移"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Console applications"
+msgid "translated application messages;"
+msgstr "控制台应用程序"
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Install [yiisoft/rbac-php](https://github.com/yiisoft/rbac-php) package:"
+msgid "This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project."
+msgstr "安装 [yiisoft/rbac-php](https://github.com/yiisoft/rbac-php) 包："
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Install the package"
+msgid "Install packages"
+msgstr "安装包"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer require yiisoft/yii-sentry --prefer-dist\n"
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr "composer require yiisoft/yii-sentry --prefer-dist\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "composer require yiisoft/yii-sentry --prefer-dist\n"
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr "composer require yiisoft/yii-sentry --prefer-dist\n"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Container configuration"
+msgid "composer yii-config-rebuild\n"
+msgstr "容器配置"
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Single application template"
+msgid "Configure application locale"
+msgstr "单一应用程序模板"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The application template keeps basic application settings in `config/common/application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Add the following configuration to `config/common/params.php`:"
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr "将以下配置添加到 `config/common/params.php`："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current locale. `defaultCategory` is the category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Configuring the Mailer"
+msgid "Configure message storage"
+msgstr "配置邮件发送器"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now create `config/common/di/db-pgsql.php`:"
+msgid "Create `config/common/di/translator.php`:"
+msgstr "现在创建 `config/common/di/db-pgsql.php`："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes extracted messages back to the same directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Flash messages"
+msgid "Translate messages"
+msgstr "闪存消息"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for a response.  For the default home page action, update `src/Web/HomePage/Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now, a template in `src/Web/Page/edit.php`:"
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr "现在，在 `src/Web/Page/edit.php` 中创建模板："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Escape translated text before output. Store trusted HTML separately or render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.  The example below uses the `lang` query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Register the middleware in `config/common/routes.php` or in the route group that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "A typical layout file such as `src/Web/Shared/Layout/Main/layout.php` looks like this:"
+msgid "Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:"
+msgstr "典型的布局文件，例如 `src/Web/Shared/Layout/Main/layout.php`，如下所示："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use message translation for labels, headings, buttons, validation messages, and short paragraphs.  Use localized view files when a page needs different markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when `src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr "创建 `src/Web/Page/DeleteAction.php`："
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr "创建 `src/Web/Page/DeleteAction.php`："
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Create `src/Web/Page/DeleteAction.php`:"
+msgid "`src/Web/HomePage/template.php`"
+msgstr "创建 `src/Web/Page/DeleteAction.php`："
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "You can set a default value for a route parameter. For example:"
+msgid "You can set the locale for a single render call:"
+msgstr "您可以为路由参数设置默认值，例如："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Flash messages"
+msgid "Extract messages"
+msgstr "闪存消息"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure the extractor so it can read existing messages and write new IDs to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Now create `config/common/di/db-pgsql.php`:"
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr "现在创建 `config/common/di/db-pgsql.php`："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy
+#| msgid "Add the command to `config/console/commands.php`:"
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr "将命令添加到 `config/console/commands.php`："
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "After extraction, edit target language files and replace source IDs with translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Working with forms"
+msgid "Working with categories"
+msgstr "使用表单"
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The default `app` category is enough for most application messages. Add categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Keep message IDs stable. Changing an ID creates a new translation task for every locale."
+msgstr ""

--- a/_translations/po/zh-CN/guide_tutorial_i18n.md.po
+++ b/_translations/po/zh-CN/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -583,7 +583,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/zh-CN/guide_tutorial_i18n.md.po
+++ b/_translations/po/zh-CN/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -583,31 +583,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-#, fuzzy
-#| msgid "Add the command to `config/console/commands.php`:"
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr "将命令添加到 `config/console/commands.php`："
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+msgid "The `translator/extract` console command is registered by `yiisoft/translator-extractor`.  Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/po/zh-CN/guide_tutorial_i18n.md.po
+++ b/_translations/po/zh-CN/guide_tutorial_i18n.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: 2026-05-09 11:15+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -24,7 +24,7 @@ msgstr "事务性迁移"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Internationalization prepares an application for more than one locale. Localization adapts the application to a specific locale, for example `en-US` or `de`."
+msgid "Internationalization prepares an application for more than one locale. Localization is the locale-specific part: translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`."
 msgstr ""
 
 #. type: Plain text
@@ -96,18 +96,6 @@ msgstr "composer require yiisoft/yii-sentry --prefer-dist\n"
 #: ../src/guide/tutorial/i18n.md
 msgid "The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple placeholders only, use `Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
 msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "After changing installed packages or configuration, rebuild the configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, fuzzy, no-wrap
-#| msgid "Container configuration"
-msgid "composer yii-config-rebuild\n"
-msgstr "容器配置"
 
 #. type: Title ##
 #: ../src/guide/tutorial/i18n.md
@@ -621,6 +609,13 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
 msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, fuzzy, no-wrap
+#| msgid "Container configuration"
+msgid "composer yii-config-rebuild\n"
+msgstr "容器配置"
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md

--- a/_translations/po4a.conf
+++ b/_translations/po4a.conf
@@ -76,6 +76,7 @@
 [type: markdown] ../src/guide/testing/unit.md $lang:../src/$lang/guide/testing/unit.md pot=guide_testing_unit.md
 [type: markdown] ../src/guide/tutorial/console-applications.md $lang:../src/$lang/guide/tutorial/console-applications.md pot=guide_tutorial_console-applications.md
 [type: markdown] ../src/guide/tutorial/docker.md $lang:../src/$lang/guide/tutorial/docker.md pot=guide_tutorial_docker.md
+[type: markdown] ../src/guide/tutorial/i18n.md $lang:../src/$lang/guide/tutorial/i18n.md pot=guide_tutorial_i18n.md
 [type: markdown] ../src/guide/tutorial/mailing.md $lang:../src/$lang/guide/tutorial/mailing.md pot=guide_tutorial_mailing.md
 [type: markdown] ../src/guide/tutorial/performance-tuning.md $lang:../src/$lang/guide/tutorial/performance-tuning.md pot=guide_tutorial_performance-tuning.md
 [type: markdown] ../src/guide/tutorial/using-with-event-loop.md $lang:../src/$lang/guide/tutorial/using-with-event-loop.md pot=guide_tutorial_using-with-event-loop.md

--- a/_translations/pot/guide_index.md.pot
+++ b/_translations/pot/guide_index.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-08 11:11+0000\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -563,7 +563,7 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../src/guide/index.md
-msgid "[Internationalization](tutorial/i18n.md) TODO"
+msgid "[Internationalization](tutorial/i18n.md)"
 msgstr ""
 
 #. type: Title ##

--- a/_translations/pot/guide_tutorial_i18n.md.pot
+++ b/_translations/pot/guide_tutorial_i18n.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:24+0000\n"
+"POT-Creation-Date: 2026-05-09 11:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -599,10 +599,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid ""
-"The `translator/extract` console command is registered by `yiisoft/"
-"translator-extractor`.  Rebuild config after adding the extractor "
-"configuration file:"
+msgid "Rebuild config after adding the extractor configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/pot/guide_tutorial_i18n.md.pot
+++ b/_translations/pot/guide_tutorial_i18n.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:21+0000\n"
+"POT-Creation-Date: 2026-05-09 11:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -599,29 +599,10 @@ msgstr ""
 
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
-msgid "Add the console command to `config/console/commands.php`:"
-msgstr ""
-
-#. type: Fenced code block (php)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
 msgid ""
-"<?php\n"
-"\n"
-"declare(strict_types=1);\n"
-"\n"
-"use App\\Console;\n"
-"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
-"\n"
-"return [\n"
-"    'hello' => Console\\HelloCommand::class,\n"
-"    'translator/extract' => ExtractCommand::class,\n"
-"];\n"
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid "Rebuild config:"
+"The `translator/extract` console command is registered by `yiisoft/"
+"translator-extractor`.  Rebuild config after adding the extractor "
+"configuration file:"
 msgstr ""
 
 #. type: Fenced code block (sh)

--- a/_translations/pot/guide_tutorial_i18n.md.pot
+++ b/_translations/pot/guide_tutorial_i18n.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"POT-Creation-Date: 2026-05-09 11:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,8 +26,9 @@ msgstr ""
 #: ../src/guide/tutorial/i18n.md
 msgid ""
 "Internationalization prepares an application for more than one locale. "
-"Localization adapts the application to a specific locale, for example `en-"
-"US` or `de`."
+"Localization is the locale-specific part: translated text, plural forms, "
+"date and number formats, and view templates for a locale such as `en-US` or "
+"`de`."
 msgstr ""
 
 #. type: Plain text
@@ -96,19 +97,6 @@ msgid ""
 "The examples use ICU message formatting for plural forms. Make sure the PHP "
 "`intl` extension is enabled. For simple placeholders only, use "
 "`Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
-msgstr ""
-
-#. type: Plain text
-#: ../src/guide/tutorial/i18n.md
-msgid ""
-"After changing installed packages or configuration, rebuild the "
-"configuration merge plan:"
-msgstr ""
-
-#. type: Fenced code block (sh)
-#: ../src/guide/tutorial/i18n.md
-#, no-wrap
-msgid "composer yii-config-rebuild\n"
 msgstr ""
 
 #. type: Title ##
@@ -634,6 +622,12 @@ msgstr ""
 #. type: Plain text
 #: ../src/guide/tutorial/i18n.md
 msgid "Rebuild config:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer yii-config-rebuild\n"
 msgstr ""
 
 #. type: Plain text

--- a/_translations/pot/guide_tutorial_i18n.md.pot
+++ b/_translations/pot/guide_tutorial_i18n.md.pot
@@ -1,0 +1,773 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-09 11:15+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Internationalization"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Internationalization prepares an application for more than one locale. "
+"Localization adapts the application to a specific locale, for example `en-"
+"US` or `de`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "In a Yii application, the usual parts are:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "locale selection for the current request;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "translated application messages;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "plural and parameter formatting;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/guide/tutorial/i18n.md
+msgid "localized view templates for pages that need different markup."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) "
+"project."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Install packages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the translator, locale helpers, and PHP-file message storage:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Install the extractor as a development dependency:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer require --dev yiisoft/translator-extractor\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"The examples use ICU message formatting for plural forms. Make sure the PHP "
+"`intl` extension is enabled. For simple placeholders only, use "
+"`Yiisoft\\Translator\\SimpleMessageFormatter` in the configuration below."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"After changing installed packages or configuration, rebuild the "
+"configuration merge plan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "composer yii-config-rebuild\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Configure application locale"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"The application template keeps basic application settings in `config/common/"
+"application.php`.  Set the source locale there:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"return [\n"
+"    'charset' => 'UTF-8',\n"
+"    'locale' => 'en-US',\n"
+"    'name' => 'My Project',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"The default layout uses this value in the `<html lang=\"\">` attribute through `ApplicationParams`.\n"
+"When your application chooses locale per request, set the selected locale on the view as shown in\n"
+"[Choosing locale per request](#choosing-locale-per-request).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Configure translator defaults in `config/common/params.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'yiisoft/translator' => [\n"
+"    'locale' => 'en-US',\n"
+"    'fallbackLocale' => 'en-US',\n"
+"    'defaultCategory' => 'app',\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"`locale` is the default translation locale. `fallbackLocale` is used when a "
+"translation is missing for the current locale. `defaultCategory` is the "
+"category used when a call to `translate()` does not specify one."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Configure message storage"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Translator\\CategorySource;\n"
+"use Yiisoft\\Translator\\IntlMessageFormatter;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    'translation.app' => [\n"
+"        'definition' => static function (Aliases $aliases) use ($params): CategorySource {\n"
+"            $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"            return new CategorySource(\n"
+"                $params['yiisoft/translator']['defaultCategory'],\n"
+"                $messageSource,\n"
+"                new IntlMessageFormatter(),\n"
+"                $messageSource,\n"
+"            );\n"
+"        },\n"
+"        'tags' => ['translation.categorySource'],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"This registers the `app` category. The `MessageSource` reads PHP arrays from "
+"the `messages/` directory and writes extracted messages back to the same "
+"directory."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create the source and target message files:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/\n"
+"├── de/\n"
+"│   └── app.php\n"
+"└── en-US/\n"
+"    └── app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/en-US/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Welcome to Yii3',\n"
+"    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "`messages/de/app.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"return [\n"
+"    'home.title' => 'Home',\n"
+"    'home.welcome' => 'Willkommen bei Yii3',\n"
+"    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',\n"
+"];\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Translate messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Inject `Yiisoft\\Translator\\TranslatorInterface` where you prepare data for "
+"a response.  For the default home page action, update `src/Web/HomePage/"
+"Action.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\HomePage;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\Yii\\View\\Renderer\\ViewRenderer;\n"
+"\n"
+"final readonly class Action\n"
+"{\n"
+"    public function __construct(\n"
+"        private ViewRenderer $viewRenderer,\n"
+"        private TranslatorInterface $translator,\n"
+"    ) {}\n"
+"\n"
+"    public function __invoke(): ResponseInterface\n"
+"    {\n"
+"        return $this->viewRenderer->render(__DIR__ . '/template', [\n"
+"            'itemCount' => 3,\n"
+"            'translator' => $this->translator,\n"
+"        ]);\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use the translator in `src/Web/HomePage/template.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Shared\\ApplicationParams;\n"
+"use Yiisoft\\Html\\Html;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"/**\n"
+" * @var WebView $this\n"
+" * @var ApplicationParams $applicationParams\n"
+" * @var int $itemCount\n"
+" * @var TranslatorInterface $translator\n"
+" */\n"
+"\n"
+"$this->setTitle($translator->translate('home.title'));\n"
+"?>\n"
+"\n"
+"<div class=\"text-center\">\n"
+"    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>\n"
+"\n"
+"    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>\n"
+"</div>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Escape translated text before output. Store trusted HTML separately or "
+"render it from a view template."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Choosing locale per request"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"For a web application, choose locale early in the middleware stack and apply "
+"it to both the translator and the view.  The example below uses the `lang` "
+"query parameter and a fixed allow-list:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"namespace App\\Web\\Middleware;\n"
+"\n"
+"use Psr\\Http\\Message\\ResponseInterface;\n"
+"use Psr\\Http\\Message\\ServerRequestInterface;\n"
+"use Psr\\Http\\Server\\MiddlewareInterface;\n"
+"use Psr\\Http\\Server\\RequestHandlerInterface;\n"
+"use Yiisoft\\Translator\\TranslatorInterface;\n"
+"use Yiisoft\\View\\WebView;\n"
+"\n"
+"final readonly class LocaleMiddleware implements MiddlewareInterface\n"
+"{\n"
+"    private const DEFAULT_LOCALE = 'en-US';\n"
+"    private const SUPPORTED_LOCALES = ['en-US', 'de'];\n"
+"\n"
+"    public function __construct(\n"
+"        private TranslatorInterface $translator,\n"
+"        private WebView $view,\n"
+"    ) {}\n"
+"\n"
+"    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface\n"
+"    {\n"
+"        $locale = $this->getLocale($request);\n"
+"\n"
+"        $this->translator->setLocale($locale);\n"
+"        $this->view->setLocale($locale);\n"
+"\n"
+"        return $handler->handle($request);\n"
+"    }\n"
+"\n"
+"    private function getLocale(ServerRequestInterface $request): string\n"
+"    {\n"
+"        $locale = $request->getQueryParams()['lang'] ?? null;\n"
+"\n"
+"        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)\n"
+"            ? $locale\n"
+"            : self::DEFAULT_LOCALE;\n"
+"    }\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Register the middleware in `config/common/routes.php` or in the route group "
+"that needs localized output.  Add middleware before the route action:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use App\\Web\\Middleware\\LocaleMiddleware;\n"
+"\n"
+"Route::get('/')\n"
+"    ->middleware(LocaleMiddleware::class)\n"
+"    ->action(App\\Web\\HomePage\\Action::class)\n"
+"    ->name('home');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the "
+"current view state:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "<html lang=\"<?= Html::encode($this->getLocale()) ?>\">\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Use the same approach when locale is stored in a session, a cookie, a user "
+"profile, or a route parameter."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"`yiisoft/i18n` provides `Yiisoft\\I18n\\Locale` for working with BCP 47 "
+"locale codes:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"use Yiisoft\\I18n\\Locale;\n"
+"\n"
+"$locale = new Locale('de-DE');\n"
+"\n"
+"echo $locale->language(); // de\n"
+"echo $locale->region(); // DE\n"
+"echo $locale->fallbackLocale()->asString(); // de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"This is useful when you need to derive a language fallback or inspect locale "
+"parts before choosing a supported locale."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Localized view files"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Use message translation for labels, headings, buttons, validation messages, "
+"and short paragraphs.  Use localized view files when a page needs different "
+"markup or a different amount of text for each locale."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"`yiisoft/view` looks for localized files in a locale subdirectory next to "
+"the original view file. For example, when `src/Web/HomePage/template.php` is "
+"rendered with locale `de-DE`, Yii checks:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de-DE/template.php`"
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/de/template.php`"
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/guide/tutorial/i18n.md
+msgid "`src/Web/HomePage/template.php`"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The fallback to the two-letter language code is automatic."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "You can set the locale for a single render call:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"return $this->viewRenderer\n"
+"    ->withLocale('de-DE')\n"
+"    ->render(__DIR__ . '/template');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"When the locale is set on `WebView` in middleware, the same locale is "
+"applied to views rendered by `ViewRenderer`."
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Extract messages"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Configure the extractor so it can read existing messages and write new IDs "
+"to the same message storage."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Create `config/common/di/translator-extractor.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use Yiisoft\\Aliases\\Aliases;\n"
+"use Yiisoft\\Definitions\\DynamicReference;\n"
+"use Yiisoft\\Translator\\Message\\Php\\MessageSource;\n"
+"use Yiisoft\\TranslatorExtractor\\CategorySource as ExtractorCategorySource;\n"
+"use Yiisoft\\TranslatorExtractor\\Extractor;\n"
+"\n"
+"/** @var array $params */\n"
+"\n"
+"return [\n"
+"    Extractor::class => [\n"
+"        '__construct()' => [\n"
+"            [\n"
+"                DynamicReference::to([\n"
+"                    'class' => ExtractorCategorySource::class,\n"
+"                    '__construct()' => [\n"
+"                        $params['yiisoft/translator']['defaultCategory'],\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                        DynamicReference::to(\n"
+"                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),\n"
+"                        ),\n"
+"                    ],\n"
+"                ]),\n"
+"            ],\n"
+"        ],\n"
+"    ],\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Add the console command to `config/console/commands.php`:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"<?php\n"
+"\n"
+"declare(strict_types=1);\n"
+"\n"
+"use App\\Console;\n"
+"use Yiisoft\\TranslatorExtractor\\Command\\ExtractCommand;\n"
+"\n"
+"return [\n"
+"    'hello' => Console\\HelloCommand::class,\n"
+"    'translator/extract' => ExtractCommand::class,\n"
+"];\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Rebuild config:"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Extract messages from application source files:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The command scans calls such as:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"$translator->translate('home.welcome');\n"
+"$translator->translate('cart.items', ['count' => $itemCount]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "It writes missing IDs to:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/en-US/app.php\n"
+"messages/de/app.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"After extraction, edit target language files and replace source IDs with "
+"translated text."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Use `--category` when a call belongs to another category:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --category=shop\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"The extractor excludes `vendor/` by default. Use `--only` or `--except` when "
+"you need a narrower scan:"
+msgstr ""
+
+#. type: Fenced code block (sh)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**\n"
+msgstr ""
+
+#. type: Title ##
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "Working with categories"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"The default `app` category is enough for most application messages. Add "
+"categories when a package or a large feature owns its own message files."
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "For a `shop` category, create another tagged category source:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"'translation.shop' => [\n"
+"    'definition' => static function (Aliases $aliases): CategorySource {\n"
+"        $messageSource = new MessageSource($aliases->get('@root/messages'));\n"
+"\n"
+"        return new CategorySource(\n"
+"            'shop',\n"
+"            $messageSource,\n"
+"            new IntlMessageFormatter(),\n"
+"            $messageSource,\n"
+"        );\n"
+"    },\n"
+"    'tags' => ['translation.categorySource'],\n"
+"],\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "Translate with the category name:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid "$translator->translate('checkout.submit', category: 'shop');\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid "The message files are stored as:"
+msgstr ""
+
+#. type: Fenced code block
+#: ../src/guide/tutorial/i18n.md
+#, no-wrap
+msgid ""
+"messages/de/shop.php\n"
+"messages/en-US/shop.php\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/guide/tutorial/i18n.md
+msgid ""
+"Keep message IDs stable. Changing an ID creates a new translation task for "
+"every locale."
+msgstr ""

--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -162,7 +162,8 @@ export default {
                                 {text: 'Using Yii with FrankenPHP', link: '/guide/tutorial/using-yii-with-frankenphp'},
                                 {text: 'Using Yii with RoadRunner', link: '/guide/tutorial/using-yii-with-roadrunner'},
                                 {text: 'Using Yii with Swoole', link: '/guide/tutorial/using-yii-with-swoole'},
-                                {text: 'Docker in Application Templates', link: '/guide/tutorial/docker'}
+                                {text: 'Docker in Application Templates', link: '/guide/tutorial/docker'},
+                                {text: 'Internationalization', link: '/guide/tutorial/i18n'}
                             ]
                         },
                         {

--- a/src/es/guide/index.md
+++ b/src/es/guide/index.md
@@ -139,7 +139,7 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Using Yii with RoadRunner](tutorial/using-yii-with-roadrunner.md)
 - [Using Yii with Swoole](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [Internationalization](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## Helpers
 

--- a/src/es/guide/tutorial/i18n.md
+++ b/src/es/guide/tutorial/i18n.md
@@ -363,9 +363,7 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by
-`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
-configuration file:
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/es/guide/tutorial/i18n.md
+++ b/src/es/guide/tutorial/i18n.md
@@ -1,0 +1,467 @@
+# Internationalization
+
+Internationalization prepares an application for more than one
+locale. Localization adapts the application to a specific locale, for
+example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app)
+project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP
+`intl` extension is enabled. For simple placeholders only, use
+`Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the
+configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in
+`config/common/application.php`.  Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a
+translation is missing for the current locale. `defaultCategory` is the
+category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from
+the `messages/` directory and writes extracted messages back to the same
+directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a
+response.  For the default home page action, update
+`src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or
+render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply
+it to both the translator and the view.  The example below uses the `lang`
+query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group
+that needs localized output.  Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the
+current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user
+profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale
+codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale
+parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages,
+and short paragraphs.  Use localized view files when a page needs different
+markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to
+the original view file. For example, when `src/Web/HomePage/template.php` is
+rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is
+applied to views rendered by `ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs
+to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with
+translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when
+you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add
+categories when a package or a large feature owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for
+every locale.

--- a/src/es/guide/tutorial/i18n.md
+++ b/src/es/guide/tutorial/i18n.md
@@ -363,23 +363,9 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by
+`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
+configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/es/guide/tutorial/i18n.md
+++ b/src/es/guide/tutorial/i18n.md
@@ -1,8 +1,9 @@
 # Internationalization
 
 Internationalization prepares an application for more than one
-locale. Localization adapts the application to a specific locale, for
-example `en-US` or `de`.
+locale. Localization is the locale-specific part: translated text, plural
+forms, date and number formats, and view templates for a locale such as
+`en-US` or `de`.
 
 In a Yii application, the usual parts are:
 
@@ -31,13 +32,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP
 `intl` extension is enabled. For simple placeholders only, use
 `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
-
-After changing installed packages or configuration, rebuild the
-configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
 
 ## Configure application locale
 

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -135,7 +135,7 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 - [Using Yii with RoadRunner](tutorial/using-yii-with-roadrunner.md)
 - [Using Yii with Swoole](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [Internationalization](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## Helpers
 

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -14,10 +14,11 @@ This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) projec
 
 ## Install packages
 
-Install the translator, locale helpers, and PHP-file message storage:
+`yiisoft/app` already includes `yiisoft/i18n` and `yiisoft/translator`.
+Install PHP-file message storage:
 
 ```sh
-composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+composer require yiisoft/translator-message-php
 ```
 
 Install the extractor as a development dependency:
@@ -147,12 +148,12 @@ namespace App\Web\HomePage;
 
 use Psr\Http\Message\ResponseInterface;
 use Yiisoft\Translator\TranslatorInterface;
-use Yiisoft\Yii\View\Renderer\ViewRenderer;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
 
 final readonly class Action
 {
     public function __construct(
-        private ViewRenderer $viewRenderer,
+        private WebViewRenderer $viewRenderer,
         private TranslatorInterface $translator,
     ) {}
 
@@ -304,7 +305,7 @@ return $this->viewRenderer
 ```
 
 When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by
-`ViewRenderer`.
+`WebViewRenderer`.
 
 ## Extract messages
 

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -29,12 +29,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple
 placeholders only, use `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
 
-After changing installed packages or configuration, rebuild the configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
-
 ## Configure application locale
 
 The application template keeps basic application settings in `config/common/application.php`.

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -347,7 +347,6 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by `yiisoft/translator-extractor`.
 Rebuild config after adding the extractor configuration file:
 
 ```sh

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -253,11 +253,14 @@ Add middleware before the route action:
 
 ```php
 use App\Web\Middleware\LocaleMiddleware;
+use Yiisoft\Router\Route;
 
-Route::get('/')
-    ->middleware(LocaleMiddleware::class)
-    ->action(App\Web\HomePage\Action::class)
-    ->name('home');
+return [
+    Route::get('/')
+        ->middleware(LocaleMiddleware::class)
+        ->action(App\Web\HomePage\Action::class)
+        ->name('home'),
+];
 ```
 
 Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -201,7 +201,7 @@ Escape translated text before output. Store trusted HTML separately or render it
 ## Choosing locale per request
 
 For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.
-The example below uses the `lang` query parameter and a fixed allow-list:
+The example below uses the `lang` query parameter and a fixed allow list:
 
 ```php
 <?php

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -1,0 +1,448 @@
+# Internationalization
+
+Internationalization prepares an application for more than one locale. Localization adapts the application to a
+specific locale, for example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app) project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP `intl` extension is enabled. For simple
+placeholders only, use `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in `config/common/application.php`.
+Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a translation is missing for the current
+locale. `defaultCategory` is the category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from the `messages/` directory and writes
+extracted messages back to the same directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a response.
+For the default home page action, update `src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply it to both the translator and the view.
+The example below uses the `lang` query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group that needs localized output.
+Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages, and short paragraphs.
+Use localized view files when a page needs different markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to the original view file. For example, when
+`src/Web/HomePage/template.php` is rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is applied to views rendered by
+`ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add categories when a package or a large feature
+owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for every locale.

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -347,23 +347,8 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by `yiisoft/translator-extractor`.
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/guide/tutorial/i18n.md
+++ b/src/guide/tutorial/i18n.md
@@ -1,7 +1,7 @@
 # Internationalization
 
-Internationalization prepares an application for more than one locale. Localization adapts the application to a
-specific locale, for example `en-US` or `de`.
+Internationalization prepares an application for more than one locale. Localization is the locale-specific part:
+translated text, plural forms, date and number formats, and view templates for a locale such as `en-US` or `de`.
 
 In a Yii application, the usual parts are:
 

--- a/src/id/guide/index.md
+++ b/src/id/guide/index.md
@@ -139,7 +139,7 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Using Yii with RoadRunner](tutorial/using-yii-with-roadrunner.md)
 - [Using Yii with Swoole](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [Internationalization](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## Helpers
 

--- a/src/id/guide/tutorial/i18n.md
+++ b/src/id/guide/tutorial/i18n.md
@@ -363,9 +363,7 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by
-`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
-configuration file:
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/id/guide/tutorial/i18n.md
+++ b/src/id/guide/tutorial/i18n.md
@@ -1,0 +1,467 @@
+# Internationalization
+
+Internationalization prepares an application for more than one
+locale. Localization adapts the application to a specific locale, for
+example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app)
+project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP
+`intl` extension is enabled. For simple placeholders only, use
+`Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the
+configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in
+`config/common/application.php`.  Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a
+translation is missing for the current locale. `defaultCategory` is the
+category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from
+the `messages/` directory and writes extracted messages back to the same
+directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a
+response.  For the default home page action, update
+`src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or
+render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply
+it to both the translator and the view.  The example below uses the `lang`
+query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group
+that needs localized output.  Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the
+current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user
+profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale
+codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale
+parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages,
+and short paragraphs.  Use localized view files when a page needs different
+markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to
+the original view file. For example, when `src/Web/HomePage/template.php` is
+rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is
+applied to views rendered by `ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs
+to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with
+translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when
+you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add
+categories when a package or a large feature owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for
+every locale.

--- a/src/id/guide/tutorial/i18n.md
+++ b/src/id/guide/tutorial/i18n.md
@@ -363,23 +363,9 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by
+`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
+configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/id/guide/tutorial/i18n.md
+++ b/src/id/guide/tutorial/i18n.md
@@ -1,8 +1,9 @@
 # Internationalization
 
 Internationalization prepares an application for more than one
-locale. Localization adapts the application to a specific locale, for
-example `en-US` or `de`.
+locale. Localization is the locale-specific part: translated text, plural
+forms, date and number formats, and view templates for a locale such as
+`en-US` or `de`.
 
 In a Yii application, the usual parts are:
 
@@ -31,13 +32,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP
 `intl` extension is enabled. For simple placeholders only, use
 `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
-
-After changing installed packages or configuration, rebuild the
-configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
 
 ## Configure application locale
 

--- a/src/it/guide/index.md
+++ b/src/it/guide/index.md
@@ -140,7 +140,7 @@ Yii](https://www.yiiframework.com/license#docs).
 - [Usare Yii con RoadRunner](tutorial/using-yii-with-roadrunner.md)
 - [Usare Yii con Swoole](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [Internazionalizzazione](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## Helper
 

--- a/src/it/guide/tutorial/i18n.md
+++ b/src/it/guide/tutorial/i18n.md
@@ -363,9 +363,7 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by
-`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
-configuration file:
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/it/guide/tutorial/i18n.md
+++ b/src/it/guide/tutorial/i18n.md
@@ -1,0 +1,467 @@
+# Internationalization
+
+Internationalization prepares an application for more than one
+locale. Localization adapts the application to a specific locale, for
+example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app)
+project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP
+`intl` extension is enabled. For simple placeholders only, use
+`Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the
+configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in
+`config/common/application.php`.  Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a
+translation is missing for the current locale. `defaultCategory` is the
+category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from
+the `messages/` directory and writes extracted messages back to the same
+directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a
+response.  For the default home page action, update
+`src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or
+render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply
+it to both the translator and the view.  The example below uses the `lang`
+query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group
+that needs localized output.  Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the
+current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user
+profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale
+codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale
+parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages,
+and short paragraphs.  Use localized view files when a page needs different
+markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to
+the original view file. For example, when `src/Web/HomePage/template.php` is
+rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is
+applied to views rendered by `ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs
+to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with
+translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when
+you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add
+categories when a package or a large feature owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for
+every locale.

--- a/src/it/guide/tutorial/i18n.md
+++ b/src/it/guide/tutorial/i18n.md
@@ -363,23 +363,9 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by
+`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
+configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/it/guide/tutorial/i18n.md
+++ b/src/it/guide/tutorial/i18n.md
@@ -1,8 +1,9 @@
 # Internationalization
 
 Internationalization prepares an application for more than one
-locale. Localization adapts the application to a specific locale, for
-example `en-US` or `de`.
+locale. Localization is the locale-specific part: translated text, plural
+forms, date and number formats, and view templates for a locale such as
+`en-US` or `de`.
 
 In a Yii application, the usual parts are:
 
@@ -31,13 +32,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP
 `intl` extension is enabled. For simple placeholders only, use
 `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
-
-After changing installed packages or configuration, rebuild the
-configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
 
 ## Configure application locale
 

--- a/src/ru/guide/index.md
+++ b/src/ru/guide/index.md
@@ -139,7 +139,7 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Using Yii with RoadRunner](tutorial/using-yii-with-roadrunner.md)
 - [Using Yii with Swoole](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [Internationalization](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## Helpers
 

--- a/src/ru/guide/tutorial/i18n.md
+++ b/src/ru/guide/tutorial/i18n.md
@@ -363,9 +363,7 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by
-`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
-configuration file:
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/ru/guide/tutorial/i18n.md
+++ b/src/ru/guide/tutorial/i18n.md
@@ -1,0 +1,467 @@
+# Internationalization
+
+Internationalization prepares an application for more than one
+locale. Localization adapts the application to a specific locale, for
+example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app)
+project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP
+`intl` extension is enabled. For simple placeholders only, use
+`Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the
+configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in
+`config/common/application.php`.  Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a
+translation is missing for the current locale. `defaultCategory` is the
+category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from
+the `messages/` directory and writes extracted messages back to the same
+directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a
+response.  For the default home page action, update
+`src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or
+render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply
+it to both the translator and the view.  The example below uses the `lang`
+query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group
+that needs localized output.  Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the
+current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user
+profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale
+codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale
+parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages,
+and short paragraphs.  Use localized view files when a page needs different
+markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to
+the original view file. For example, when `src/Web/HomePage/template.php` is
+rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is
+applied to views rendered by `ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs
+to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with
+translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when
+you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add
+categories when a package or a large feature owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for
+every locale.

--- a/src/ru/guide/tutorial/i18n.md
+++ b/src/ru/guide/tutorial/i18n.md
@@ -363,23 +363,9 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by
+`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
+configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/ru/guide/tutorial/i18n.md
+++ b/src/ru/guide/tutorial/i18n.md
@@ -1,8 +1,9 @@
 # Internationalization
 
 Internationalization prepares an application for more than one
-locale. Localization adapts the application to a specific locale, for
-example `en-US` or `de`.
+locale. Localization is the locale-specific part: translated text, plural
+forms, date and number formats, and view templates for a locale such as
+`en-US` or `de`.
 
 In a Yii application, the usual parts are:
 
@@ -31,13 +32,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP
 `intl` extension is enabled. For simple placeholders only, use
 `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
-
-After changing installed packages or configuration, rebuild the
-configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
 
 ## Configure application locale
 

--- a/src/zh-CN/guide/index.md
+++ b/src/zh-CN/guide/index.md
@@ -137,7 +137,7 @@
 - [在 RoadRunner 中使用 Yii](tutorial/using-yii-with-roadrunner.md)
 - [在 Swoole 中使用 Yii](tutorial/using-yii-with-swoole.md)
 - [Docker in application templates](tutorial/docker.md)
-- [国际化](tutorial/i18n.md) TODO
+- [Internationalization](tutorial/i18n.md)
 
 ## 助手类
 

--- a/src/zh-CN/guide/tutorial/i18n.md
+++ b/src/zh-CN/guide/tutorial/i18n.md
@@ -363,9 +363,7 @@ return [
 ];
 ```
 
-The `translator/extract` console command is registered by
-`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
-configuration file:
+Rebuild config after adding the extractor configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/zh-CN/guide/tutorial/i18n.md
+++ b/src/zh-CN/guide/tutorial/i18n.md
@@ -1,0 +1,467 @@
+# Internationalization
+
+Internationalization prepares an application for more than one
+locale. Localization adapts the application to a specific locale, for
+example `en-US` or `de`.
+
+In a Yii application, the usual parts are:
+
+- locale selection for the current request;
+- translated application messages;
+- plural and parameter formatting;
+- localized view templates for pages that need different markup.
+
+This tutorial assumes a new [yiisoft/app](https://github.com/yiisoft/app)
+project.
+
+## Install packages
+
+Install the translator, locale helpers, and PHP-file message storage:
+
+```sh
+composer require yiisoft/i18n yiisoft/translator yiisoft/translator-message-php
+```
+
+Install the extractor as a development dependency:
+
+```sh
+composer require --dev yiisoft/translator-extractor
+```
+
+The examples use ICU message formatting for plural forms. Make sure the PHP
+`intl` extension is enabled. For simple placeholders only, use
+`Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
+
+After changing installed packages or configuration, rebuild the
+configuration merge plan:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Configure application locale
+
+The application template keeps basic application settings in
+`config/common/application.php`.  Set the source locale there:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'charset' => 'UTF-8',
+    'locale' => 'en-US',
+    'name' => 'My Project',
+];
+```
+
+The default layout uses this value in the `<html lang="">` attribute through `ApplicationParams`.
+When your application chooses locale per request, set the selected locale on the view as shown in
+[Choosing locale per request](#choosing-locale-per-request).
+
+Configure translator defaults in `config/common/params.php`:
+
+```php
+'yiisoft/translator' => [
+    'locale' => 'en-US',
+    'fallbackLocale' => 'en-US',
+    'defaultCategory' => 'app',
+],
+```
+
+`locale` is the default translation locale. `fallbackLocale` is used when a
+translation is missing for the current locale. `defaultCategory` is the
+category used when a call to `translate()` does not specify one.
+
+## Configure message storage
+
+Create `config/common/di/translator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+/** @var array $params */
+
+return [
+    'translation.app' => [
+        'definition' => static function (Aliases $aliases) use ($params): CategorySource {
+            $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+            return new CategorySource(
+                $params['yiisoft/translator']['defaultCategory'],
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+This registers the `app` category. The `MessageSource` reads PHP arrays from
+the `messages/` directory and writes extracted messages back to the same
+directory.
+
+Create the source and target message files:
+
+```
+messages/
+├── de/
+│   └── app.php
+└── en-US/
+    └── app.php
+```
+
+`messages/en-US/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Welcome to Yii3',
+    'cart.items' => '{count, plural, =0{No items} one{# item} other{# items}}',
+];
+```
+
+`messages/de/app.php`:
+
+```php
+<?php
+
+return [
+    'home.title' => 'Home',
+    'home.welcome' => 'Willkommen bei Yii3',
+    'cart.items' => '{count, plural, =0{Keine Artikel} one{# Artikel} other{# Artikel}}',
+];
+```
+
+## Translate messages
+
+Inject `Yiisoft\Translator\TranslatorInterface` where you prepare data for a
+response.  For the default home page action, update
+`src/Web/HomePage/Action.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\Yii\View\Renderer\ViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private ViewRenderer $viewRenderer,
+        private TranslatorInterface $translator,
+    ) {}
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'itemCount' => 3,
+            'translator' => $this->translator,
+        ]);
+    }
+}
+```
+
+Use the translator in `src/Web/HomePage/template.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var int $itemCount
+ * @var TranslatorInterface $translator
+ */
+
+$this->setTitle($translator->translate('home.title'));
+?>
+
+<div class="text-center">
+    <h1><?= Html::encode($translator->translate('home.welcome')) ?></h1>
+
+    <p><?= Html::encode($translator->translate('cart.items', ['count' => $itemCount])) ?></p>
+</div>
+```
+
+Escape translated text before output. Store trusted HTML separately or
+render it from a view template.
+
+## Choosing locale per request
+
+For a web application, choose locale early in the middleware stack and apply
+it to both the translator and the view.  The example below uses the `lang`
+query parameter and a fixed allow-list:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Translator\TranslatorInterface;
+use Yiisoft\View\WebView;
+
+final readonly class LocaleMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_LOCALE = 'en-US';
+    private const SUPPORTED_LOCALES = ['en-US', 'de'];
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private WebView $view,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $locale = $this->getLocale($request);
+
+        $this->translator->setLocale($locale);
+        $this->view->setLocale($locale);
+
+        return $handler->handle($request);
+    }
+
+    private function getLocale(ServerRequestInterface $request): string
+    {
+        $locale = $request->getQueryParams()['lang'] ?? null;
+
+        return is_string($locale) && in_array($locale, self::SUPPORTED_LOCALES, true)
+            ? $locale
+            : self::DEFAULT_LOCALE;
+    }
+}
+```
+
+Register the middleware in `config/common/routes.php` or in the route group
+that needs localized output.  Add middleware before the route action:
+
+```php
+use App\Web\Middleware\LocaleMiddleware;
+
+Route::get('/')
+    ->middleware(LocaleMiddleware::class)
+    ->action(App\Web\HomePage\Action::class)
+    ->name('home');
+```
+
+Update `src/Web/Shared/Layout/Main/layout.php` to read the locale from the
+current view state:
+
+```php
+<html lang="<?= Html::encode($this->getLocale()) ?>">
+```
+
+Use the same approach when locale is stored in a session, a cookie, a user
+profile, or a route parameter.
+
+`yiisoft/i18n` provides `Yiisoft\I18n\Locale` for working with BCP 47 locale
+codes:
+
+```php
+use Yiisoft\I18n\Locale;
+
+$locale = new Locale('de-DE');
+
+echo $locale->language(); // de
+echo $locale->region(); // DE
+echo $locale->fallbackLocale()->asString(); // de
+```
+
+This is useful when you need to derive a language fallback or inspect locale
+parts before choosing a supported locale.
+
+## Localized view files
+
+Use message translation for labels, headings, buttons, validation messages,
+and short paragraphs.  Use localized view files when a page needs different
+markup or a different amount of text for each locale.
+
+`yiisoft/view` looks for localized files in a locale subdirectory next to
+the original view file. For example, when `src/Web/HomePage/template.php` is
+rendered with locale `de-DE`, Yii checks:
+
+1. `src/Web/HomePage/de-DE/template.php`
+2. `src/Web/HomePage/de/template.php`
+3. `src/Web/HomePage/template.php`
+
+The fallback to the two-letter language code is automatic.
+
+You can set the locale for a single render call:
+
+```php
+return $this->viewRenderer
+    ->withLocale('de-DE')
+    ->render(__DIR__ . '/template');
+```
+
+When the locale is set on `WebView` in middleware, the same locale is
+applied to views rendered by `ViewRenderer`.
+
+## Extract messages
+
+Configure the extractor so it can read existing messages and write new IDs
+to the same message storage.
+
+Create `config/common/di/translator-extractor.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Translator\Message\Php\MessageSource;
+use Yiisoft\TranslatorExtractor\CategorySource as ExtractorCategorySource;
+use Yiisoft\TranslatorExtractor\Extractor;
+
+/** @var array $params */
+
+return [
+    Extractor::class => [
+        '__construct()' => [
+            [
+                DynamicReference::to([
+                    'class' => ExtractorCategorySource::class,
+                    '__construct()' => [
+                        $params['yiisoft/translator']['defaultCategory'],
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                        DynamicReference::to(
+                            static fn (Aliases $aliases): MessageSource => new MessageSource($aliases->get('@root/messages')),
+                        ),
+                    ],
+                ]),
+            ],
+        ],
+    ],
+];
+```
+
+Add the console command to `config/console/commands.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Console;
+use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
+
+return [
+    'hello' => Console\HelloCommand::class,
+    'translator/extract' => ExtractCommand::class,
+];
+```
+
+Rebuild config:
+
+```sh
+composer yii-config-rebuild
+```
+
+Extract messages from application source files:
+
+```sh
+./yii translator/extract src --languages=en-US,de
+```
+
+The command scans calls such as:
+
+```php
+$translator->translate('home.welcome');
+$translator->translate('cart.items', ['count' => $itemCount]);
+```
+
+It writes missing IDs to:
+
+```
+messages/en-US/app.php
+messages/de/app.php
+```
+
+After extraction, edit target language files and replace source IDs with
+translated text.
+
+Use `--category` when a call belongs to another category:
+
+```sh
+./yii translator/extract src --languages=en-US,de --category=shop
+```
+
+The extractor excludes `vendor/` by default. Use `--only` or `--except` when
+you need a narrower scan:
+
+```sh
+./yii translator/extract src --languages=en-US,de --only=**/*.php --except=**/runtime/**
+```
+
+## Working with categories
+
+The default `app` category is enough for most application messages. Add
+categories when a package or a large feature owns its own message files.
+
+For a `shop` category, create another tagged category source:
+
+```php
+'translation.shop' => [
+    'definition' => static function (Aliases $aliases): CategorySource {
+        $messageSource = new MessageSource($aliases->get('@root/messages'));
+
+        return new CategorySource(
+            'shop',
+            $messageSource,
+            new IntlMessageFormatter(),
+            $messageSource,
+        );
+    },
+    'tags' => ['translation.categorySource'],
+],
+```
+
+Translate with the category name:
+
+```php
+$translator->translate('checkout.submit', category: 'shop');
+```
+
+The message files are stored as:
+
+```
+messages/de/shop.php
+messages/en-US/shop.php
+```
+
+Keep message IDs stable. Changing an ID creates a new translation task for
+every locale.

--- a/src/zh-CN/guide/tutorial/i18n.md
+++ b/src/zh-CN/guide/tutorial/i18n.md
@@ -363,23 +363,9 @@ return [
 ];
 ```
 
-Add the console command to `config/console/commands.php`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use App\Console;
-use Yiisoft\TranslatorExtractor\Command\ExtractCommand;
-
-return [
-    'hello' => Console\HelloCommand::class,
-    'translator/extract' => ExtractCommand::class,
-];
-```
-
-Rebuild config:
+The `translator/extract` console command is registered by
+`yiisoft/translator-extractor`.  Rebuild config after adding the extractor
+configuration file:
 
 ```sh
 composer yii-config-rebuild

--- a/src/zh-CN/guide/tutorial/i18n.md
+++ b/src/zh-CN/guide/tutorial/i18n.md
@@ -1,8 +1,9 @@
 # Internationalization
 
 Internationalization prepares an application for more than one
-locale. Localization adapts the application to a specific locale, for
-example `en-US` or `de`.
+locale. Localization is the locale-specific part: translated text, plural
+forms, date and number formats, and view templates for a locale such as
+`en-US` or `de`.
 
 In a Yii application, the usual parts are:
 
@@ -31,13 +32,6 @@ composer require --dev yiisoft/translator-extractor
 The examples use ICU message formatting for plural forms. Make sure the PHP
 `intl` extension is enabled. For simple placeholders only, use
 `Yiisoft\Translator\SimpleMessageFormatter` in the configuration below.
-
-After changing installed packages or configuration, rebuild the
-configuration merge plan:
-
-```sh
-composer yii-config-rebuild
-```
 
 ## Configure application locale
 


### PR DESCRIPTION
Closes #357.

- Adds a practical i18n tutorial for yiisoft/app covering locale setup, translator configuration, messages, request locale selection, localized views, extraction, and categories.
- Adds the page to the guide TOC, VitePress sidebar, and po4a source list.

Verified:
- git diff --check
- node --check src/.vitepress/config.js