### PR TITLE
Changed the error of '/*' instead of '/**' in the example view.php fi…

### DIFF
--- a/src/guide/start/databases.md
+++ b/src/guide/start/databases.md
@@ -588,7 +588,7 @@ use Yiisoft\Yii\View\Renderer\Csrf;
 
 /** @var Page $page */
 /** @var UrlGeneratorInterface $urlGenerator */
-/* @var Csrf $csrf */
+/** @var Csrf $csrf */
 ?>
 
 <h1><?= Html::a('Pages', $urlGenerator->generate('page/list')) ?> → <?= Html::encode($page->title) ?></h1>


### PR DESCRIPTION
## Slight typo fix in src/guide/start/databases.md

In the database.md's template for src/Web/Page/view.php line 591 reads as '/\* \@var Csrf $csrf \*/'. If run with that line of code it will throw an error. It should read '/\** \@var Csrf $csrf \*/'.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Typo in databases.md
