### PR TITLE
Fix #110, Fix #306, Fix #307: Expand Yii migration guides

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -50,6 +50,7 @@ export default {
                             text: 'Introduction',
                             items: [
                                 {text: 'About Yii', link: '/guide/intro/what-is-yii'},
+                                {text: 'Upgrading from Version 1.1', link: '/guide/intro/upgrade-from-v1'},
                                 {text: 'Upgrading from Version 2', link: '/guide/intro/upgrade-from-v2'}
                             ]
                         },

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -5,6 +5,7 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 ## Introduction
 
 - [About Yii](intro/what-is-yii.md)
+- [Upgrading from version 1.1](intro/upgrade-from-v1.md)
 - [Upgrading from version 2.0](intro/upgrade-from-v2.md)
 
 ## Getting started

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -64,9 +64,9 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 
 - [Caching overview](caching/overview.md)
 - [Data caching](caching/data.md)
-- [Fragment caching](caching/fragment.md) TODO
-- [Page caching](caching/page.md) TODO
-- [HTTP caching](caching/http.md) TODO
+- Fragment caching TODO
+- Page caching TODO
+- HTTP caching TODO
 
 ## Working with databases
 
@@ -85,29 +85,29 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 
 ## Getting data from users
 
-- [Creating forms](input/forms.md) TODO
+- Creating forms TODO
 - [Validating input](https://github.com/yiisoft/validator/blob/master/docs/guide/en/README.md)
-- [Uploading files](input/file-upload.md) TODO
-- [Collecting tabular input](input/tabular-input.md) TODO
+- Uploading files TODO
+- Collecting tabular input TODO
 
 ## Displaying data
 
-- [Data formatting](output/formatting.md) TODO
-- [Pagination](output/pagination.md) TODO
-- [Sorting](output/sorting.md) TODO
-- [Data providers](output/data-providers.md) TODO
-- [Data widgets](output/data-widgets.md) TODO
+- Data formatting TODO
+- Pagination TODO
+- Sorting TODO
+- Data providers TODO
+- Data widgets TODO
 
 ## REST APIs
 
-- [Quick start](rest/quick-start.md) TODO
-- [Resources](rest/resources.md) TODO
-- [Controllers](rest/controllers.md) TODO
-- [Routing](rest/routing.md) TODO
-- [Authentication](rest/authentication.md) TODO
-- [Rate limiting](rest/rate-limiting.md) TODO
-- [Versioning](rest/versioning.md) TODO
-- [Error handling](rest/error-handling.md) TODO
+- Quick start TODO
+- Resources TODO
+- Controllers TODO
+- Routing TODO
+- Authentication TODO
+- Rate limiting TODO
+- Versioning TODO
+- Error handling TODO
 
 ## Development tools
 

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -153,7 +153,7 @@ In Yii3, configuration is split by purpose and services are wired through the co
 - shared service definitions in `config/common/di/*.php`;
 - web-only service definitions in `config/web/di/*.php`;
 - routes in `config/common/routes.php`;
-- console commands in `config/console`.
+- console commands in `config/console/*.php`.
 
 The default template's console DI group reuses shared definitions from `config/common/di/*.php`. If you need
 console-only container definitions, add files for them to the `di-console` group in `config/configuration.php` and

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -150,9 +150,14 @@ In Yii3, configuration is split by purpose and services are wired through the co
 
 - aliases in `config/common/aliases.php`;
 - parameters in `config/common/params.php` and environment files;
-- service definitions in `config/common/di`, `config/web/di`, and `config/console`;
+- shared service definitions in `config/common/di/*.php`;
+- web-only service definitions in `config/web/di/*.php`;
 - routes in `config/common/routes.php`;
 - console commands in `config/console`.
+
+The default template's console DI group reuses shared definitions from `config/common/di/*.php`. If you need
+console-only container definitions, add files for them to the `di-console` group in `config/configuration.php` and
+rebuild the merge plan.
 
 Replace `Yii::app()->componentName` with constructor-injected services:
 

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -467,7 +467,7 @@ Yii 1.1 code may use `CDbCriteria`, `CDbCommand`, `CActiveDataProvider`, and `CG
 use `yiisoft/db` for database access and query building, and `yiisoft/data` / `yiisoft/yii-dataview` for data readers
 and widgets.
 
-Migrations are not compatible across Yii 1.1, Yii 2.0, and Yii3. For an existing application, create a baseline from
+Migrations are not compatible across Yii 1.1 and Yii3. For an existing application, create a baseline from
 the current schema and use Yii3 migrations for new changes.
 
 See [Working with databases](../start/databases.md) and [Migrations](../databases/db-migrations.md).

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -495,7 +495,6 @@ Yii3 uses [yiisoft/yii-dataview](https://github.com/yiisoft/yii-dataview):
 use Yiisoft\Data\Reader\ReadableDataInterface;
 use Yiisoft\Yii\DataView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
-use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
 use Yiisoft\Yii\DataView\GridView\GridView;
 
 /**
@@ -507,9 +506,7 @@ echo GridView::widget()
     ->columns(
         new DataColumn('id'),
         new DataColumn('title'),
-        new ActionColumn(
-            urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
-        ),
+        new ActionColumn(),
     );
 ```
 

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -7,8 +7,9 @@ Yii3 is not an incremental upgrade from Yii 1.1. Yii 2.0 was a full rewrite, and
 Composer packages, namespaces, PHP 8, PSR interfaces, dependency injection, explicit routes, middleware, and separate
 packages for features that were built into the framework in Yii 1.1.
 
-Treat a Yii 1.1 migration as a new Yii3 application that reuses domain knowledge, database schema, templates, and
-selected code after refactoring. A direct search-and-replace conversion is not realistic.
+Treat this as building a new Yii3 application with the benefit of Yii 1.1 experience. Reuse the domain knowledge,
+database schema, user workflows, and selected code after refactoring. Do not try to reproduce the Yii 1.1 application
+structure in Yii3. A direct search-and-replace conversion is not realistic.
 
 For additional background, read the Yii 2.0 guide section
 [Upgrading from Version 1.1](https://www.yiiframework.com/doc/guide/2.0/en/intro-upgrade-from-v1). It explains the
@@ -16,16 +17,18 @@ first major break from Yii 1.1: Composer, namespaces, object configuration, view
 widgets, assets, helpers, forms, query builder, Active Record, and URL management. Yii3 builds on many of those changes
 and makes dependencies more explicit.
 
-## Recommended migration strategy
+## Recommended approach
 
 Choose one of these paths:
 
-- Port Yii 1.1 to Yii3 directly when the application is small or you are already rewriting request flows.
-- Port Yii 1.1 concepts to Yii 2.0 first when the team needs a smaller conceptual step.
+- Build a new Yii3 application directly when the Yii 1.1 application is small or you are already rewriting request
+  flows.
+- Move Yii 1.1 concepts to Yii 2.0 first when the team needs a smaller conceptual step.
 - Keep Yii 1.1 running and rebuild critical flows in Yii3 one by one.
 
 For most long-lived applications, the third option is the least risky. Create a Yii3 application, connect it to the
-same database, and port vertical slices: route, action, input validation, persistence, view, assets, and tests.
+same database, and build vertical slices: route, action, input validation, persistence, view, assets, and tests.
+Each slice should be idiomatic Yii3, even when it is based on behavior from the Yii 1.1 application.
 
 ## PHP, Composer, and namespaces
 
@@ -68,8 +71,9 @@ Run:
 composer dump-autoload
 ```
 
-When porting a class, give it a namespace, add strict types, replace Yii 1.1 base classes, and inject dependencies
-instead of reading them from global application state.
+When reusing a class, give it a namespace, add strict types, replace Yii 1.1 base classes, and inject dependencies
+instead of reading them from global application state. If these changes make the class awkward, use the old class as a
+specification and write a new Yii3 class instead.
 
 ## Project structure
 
@@ -101,7 +105,7 @@ src/
 tests/
 ```
 
-Typical moves are:
+Typical mappings to consider are:
 
 | Yii 1.1 | Yii3 |
 |---------|------|
@@ -247,7 +251,8 @@ return [
 ];
 ```
 
-Port routes before action bodies. It gives you a checklist of all request flows that still need migration.
+Define routes before action bodies. It gives you a checklist of request flows you decided to keep in the Yii3
+application.
 
 See [Actions](../structure/action.md), [Middleware](../structure/middleware.md), and
 [Routing and URL generation](../runtime/routing.md).
@@ -511,8 +516,8 @@ echo GridView::widget()
     );
 ```
 
-Port the old data provider into a query service that returns a data reader. Port filters to validator rules and route
-or query parameters.
+Replace the old data provider with a query service that returns a data reader. Model filters as validator rules and
+route or query parameters.
 
 See [Using htmx for partial reloads](../../cookbook/using-htmx-for-partial-reloads.md) and
 [yii-dataview GridView docs](https://github.com/yiisoft/yii-dataview/blob/master/docs/en/guide/gridview.md).
@@ -537,7 +542,7 @@ $url = $urlGenerator->generate('post/view', ['id' => $post->getId()]);
 echo Html::a('View', $url)->render();
 ```
 
-Prefer named routes. They make views and GridView action columns easier to port.
+Prefer named routes. They make views and GridView action columns easier to design and maintain.
 
 See [Routing and URL generation](../runtime/routing.md).
 
@@ -567,7 +572,7 @@ autoloading. In Yii3:
 
 - replace helper calls with `yiisoft/html`, `yiisoft/arrays`, `yiisoft/strings`, or application helpers;
 - replace extensions with Composer packages;
-- port custom widgets to `yiisoft/widget` or plain services/templates;
+- rebuild custom widgets with `yiisoft/widget` or plain services/templates;
 - replace jQuery UI and Bootstrap widgets with current frontend packages or Yii3 widget packages where available.
 
 See [Widgets](../views/widget.md).
@@ -615,16 +620,16 @@ translator message package and inject translation services where needed.
 
 See [Internationalization](../tutorial/i18n.md).
 
-## What to refactor before porting
+## What to refactor before reusing
 
-These Yii 1.1 refactorings reduce migration risk:
+These Yii 1.1 refactorings make the old behavior easier to understand and reuse:
 
 - isolate database queries from controllers;
 - remove direct `Yii::app()` access from domain code;
 - move validation out of Active Record when it describes request input rather than database invariants;
 - replace large controller actions with services;
 - document all routes and URL rules;
-- add tests around the flows you plan to port first;
+- add tests around the flows you plan to rebuild first;
 - upgrade PHP syntax gradually if the old runtime allows it.
 
 The goal is not to make Yii 1.1 look like Yii3. The goal is to reduce hidden coupling before the code crosses the

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -30,6 +30,64 @@ For most long-lived applications, the third option is the least risky. Create a 
 same database, and build vertical slices: route, action, input validation, persistence, view, assets, and tests.
 Each slice should be idiomatic Yii3, even when it is based on behavior from the Yii 1.1 application.
 
+## Prepare the Yii 1.1 application
+
+Useful preparation can happen before the Yii3 application is ready. These refactorings make old behavior easier to
+understand and reduce the amount of Yii 1.1 framework state that crosses into the new code:
+
+- Remove direct `Yii::app()` access from reusable code where practical. If a full refactoring is too large, keep
+  `Yii::app()` calls near controllers, widgets, and commands, then pass values and services to lower-level code
+  explicitly.
+- Introduce repositories or query services for database reads currently spread across controllers, views,
+  `CActiveRecord` methods, and widgets. Yii3 can use Active Record, but it does not require it for every persistence
+  task.
+- Separate business rules from framework infrastructure. Code that does not extend `CComponent`, read global
+  application state, or render views is easier to reuse as a specification for Yii3 code.
+- Move reusable behavior out of large controllers and Active Record classes into Yii 1.1 application components or
+  plain services. Yii3 services are configured and injected differently, but the responsibility boundary is similar.
+- Add tests or characterization checks around routes and workflows you plan to rebuild first. They become the
+  executable specification for the Yii3 slice.
+
+For example, instead of reading post archive data directly from several controllers or widgets, create a small service
+that describes the application need:
+
+```php
+class PostRepository extends CComponent
+{
+    public function getArchive()
+    {
+        // ...
+    }
+
+    public function getTopForFrontPage($limit = 10)
+    {
+        // ...
+    }
+}
+```
+
+The Yii3 implementation may use `yiisoft/active-record`, `yiisoft/db`, or another persistence layer. The important
+point is that controllers and views no longer need to know that detail.
+
+## Things to learn before starting
+
+Some Yii3 application-template choices are likely to be new in a Yii 1.1 codebase:
+
+- [Composer](https://getcomposer.org/). Yii3 applications and packages are installed through Composer and loaded with
+  PSR-4 autoloading.
+- [Namespaces](https://www.php.net/manual/en/language.namespaces.php). Yii3 classes are namespaced instead of using
+  Yii 1.1-style class prefixes and path aliases for class loading.
+- [Docker](https://www.docker.com/get-started/). The default Yii3 application template includes Docker configuration.
+  Using it gives each application its own repeatable environment and reduces differences between local development and
+  production.
+- [Environment variables](https://en.wikipedia.org/wiki/Environment_variable). Yii3 templates commonly use them for
+  environment-specific settings and secrets, especially in Docker-based deployments. This follows the same idea as
+  [12-factor app configuration](https://12factor.net/config).
+- [Actions](../structure/action.md). Yii3 does not require controller inheritance. A route can point to any callable,
+  and the default template uses invokable action classes.
+- [Application structure](../structure/overview.md). Yii3's default structure is different from Yii 1.1. Start with
+  the Yii3 template and change it only when the application needs it.
+
 ## PHP, Composer, and namespaces
 
 Yii 1.1 applications commonly rely on PHP 5-era code, class prefixes such as `CController`, and autoloading by class

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -1,0 +1,631 @@
+# Upgrading from Version 1.1
+
+> If you haven't used Yii 1.1, you can skip this section and get directly to
+> "[getting started](../start/prerequisites.md)" section.
+
+Yii3 is not an incremental upgrade from Yii 1.1. Yii 2.0 was a full rewrite, and Yii3 changes the architecture again:
+Composer packages, namespaces, PHP 8, PSR interfaces, dependency injection, explicit routes, middleware, and separate
+packages for features that were built into the framework in Yii 1.1.
+
+Treat a Yii 1.1 migration as a new Yii3 application that reuses domain knowledge, database schema, templates, and
+selected code after refactoring. A direct search-and-replace conversion is not realistic.
+
+For additional background, read the Yii 2.0 guide section
+[Upgrading from Version 1.1](https://www.yiiframework.com/doc/guide/2.0/en/intro-upgrade-from-v1). It explains the
+first major break from Yii 1.1: Composer, namespaces, object configuration, view changes, controller return values,
+widgets, assets, helpers, forms, query builder, Active Record, and URL management. Yii3 builds on many of those changes
+and makes dependencies more explicit.
+
+## Recommended migration strategy
+
+Choose one of these paths:
+
+- Port Yii 1.1 to Yii3 directly when the application is small or you are already rewriting request flows.
+- Port Yii 1.1 concepts to Yii 2.0 first when the team needs a smaller conceptual step.
+- Keep Yii 1.1 running and rebuild critical flows in Yii3 one by one.
+
+For most long-lived applications, the third option is the least risky. Create a Yii3 application, connect it to the
+same database, and port vertical slices: route, action, input validation, persistence, view, assets, and tests.
+
+## PHP, Composer, and namespaces
+
+Yii 1.1 applications commonly rely on PHP 5-era code, class prefixes such as `CController`, and autoloading by class
+name. Yii3 applications require modern PHP and Composer autoloading.
+
+Yii 1.1:
+
+```php
+class SiteController extends CController
+{
+}
+```
+
+Yii3:
+
+```php
+namespace App\Web\HomePage;
+
+final readonly class Action
+{
+}
+```
+
+Configure your application namespace with PSR-4:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+```
+
+Run:
+
+```shell
+composer dump-autoload
+```
+
+When porting a class, give it a namespace, add strict types, replace Yii 1.1 base classes, and inject dependencies
+instead of reading them from global application state.
+
+## Project structure
+
+A Yii 1.1 application often uses:
+
+```text
+protected/
+  commands/
+  components/
+  config/
+  controllers/
+  extensions/
+  messages/
+  migrations/
+  models/
+  views/
+themes/
+webroot/
+```
+
+The current Yii3 application template uses:
+
+```text
+assets/
+config/
+public/
+runtime/
+src/
+tests/
+```
+
+Typical moves are:
+
+| Yii 1.1 | Yii3 |
+|---------|------|
+| `protected/controllers` | `src/Web/*/Action.php` or controller-like services |
+| `protected/models` | `src/Domain`, `src/Shared`, `src/Db`, or form models by responsibility |
+| `protected/views` | templates near the feature, for example `src/Web/HomePage/template.php` |
+| `protected/views/layouts` | layout templates and assets under `src/Web/Shared/Layout` |
+| `protected/components` | services configured in the dependency injection container |
+| `protected/extensions` | Composer packages or local packages |
+| `protected/commands` | `src/Console/*Command.php` |
+| `protected/messages` | translator message files |
+| `protected/config` | `config/common`, `config/web`, `config/console`, `config/environments` |
+| `webroot` | `public` |
+
+Do not recreate `protected` in Yii3. Put PHP source under `src`, public files under `public`, generated/runtime files
+under `runtime`, and configuration under `config`.
+
+## Configuration and application components
+
+Yii 1.1 configuration is usually one large array:
+
+```php
+return [
+    'basePath' => dirname(__DIR__),
+    'components' => [
+        'db' => [
+            'connectionString' => 'mysql:host=localhost;dbname=app',
+            'username' => 'root',
+            'password' => '',
+        ],
+        'urlManager' => [
+            'urlFormat' => 'path',
+            'rules' => [
+                'post/<id:\d+>' => 'post/view',
+            ],
+        ],
+    ],
+];
+```
+
+In Yii3, configuration is split by purpose and services are wired through the container:
+
+- aliases in `config/common/aliases.php`;
+- parameters in `config/common/params.php` and environment files;
+- service definitions in `config/common/di`, `config/web/di`, and `config/console`;
+- routes in `config/common/routes.php`;
+- console commands in `config/console`.
+
+Replace `Yii::app()->componentName` with constructor-injected services:
+
+```php
+use Yiisoft\Db\Connection\ConnectionInterface;
+use Yiisoft\Router\UrlGeneratorInterface;
+
+final readonly class PostRepository
+{
+    public function __construct(
+        private ConnectionInterface $db,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+}
+```
+
+See [Configuration](../concept/configuration.md), [Aliases](../concept/aliases.md), and
+[Dependency injection container](../concept/di-container.md).
+
+## Entry script
+
+Yii 1.1 entry scripts commonly load `yii.php` and create a web application:
+
+```php
+require_once __DIR__ . '/../framework/yii.php';
+
+Yii::createWebApplication($config)->run();
+```
+
+Yii3 entry scripts load Composer and bootstrap the configured application. Start with the `public/index.php` file from
+`yiisoft/app` and adjust configuration instead of building the application manually in the entry script.
+
+See [Entry scripts](../structure/entry-script.md) and [Application workflow](../start/workflow.md).
+
+## Controllers, actions, and routes
+
+Yii 1.1 controllers extend `CController`, and actions are methods named `actionName`:
+
+```php
+class PostController extends CController
+{
+    public function actionView($id)
+    {
+        $post = Post::model()->findByPk($id);
+
+        if ($post === null) {
+            throw new CHttpException(404);
+        }
+
+        $this->render('view', ['post' => $post]);
+    }
+}
+```
+
+Yii3 does not require controller inheritance. The current template uses invokable action classes:
+
+```php
+namespace App\Web\Post\View;
+
+use App\Post\PostRepository;
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Router\CurrentRoute;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private CurrentRoute $currentRoute,
+        private PostRepository $posts,
+        private WebViewRenderer $viewRenderer,
+    ) {
+    }
+
+    public function __invoke(): ResponseInterface
+    {
+        $post = $this->posts->findById((int) $this->currentRoute->getArgument('id'));
+
+        return $this->viewRenderer->render(__DIR__ . '/template', [
+            'post' => $post,
+        ]);
+    }
+}
+```
+
+The route is explicit:
+
+```php
+use App\Web\Post\View;
+use Yiisoft\Router\Route;
+
+return [
+    Route::get('/post/{id:\d+}')
+        ->action(View\Action::class)
+        ->name('post/view'),
+];
+```
+
+Port routes before action bodies. It gives you a checklist of all request flows that still need migration.
+
+See [Actions](../structure/action.md), [Middleware](../structure/middleware.md), and
+[Routing and URL generation](../runtime/routing.md).
+
+## Requests, responses, redirects, sessions, and cookies
+
+Yii 1.1 code often reads and writes through `Yii::app()`:
+
+```php
+$id = Yii::app()->request->getParam('id');
+Yii::app()->user->setFlash('success', 'Saved.');
+$this->redirect(['post/view', 'id' => $id]);
+```
+
+Yii3 uses PSR-7 request and response objects and injectable services. Request input is available from
+`ServerRequestInterface`; redirects, sessions, cookies, and responses are explicit dependencies.
+
+See [Request](../runtime/request.md), [Response](../runtime/response.md), [Sessions](../runtime/sessions.md), and
+[Cookies](../runtime/cookies.md).
+
+## Views and layouts
+
+Yii 1.1 views use `$this` as the controller or widget context. Layouts and partials are rendered through controller
+methods:
+
+```php
+<?php
+/* @var $this PostController */
+/* @var $post Post */
+?>
+
+<h1><?php echo CHtml::encode($post->title); ?></h1>
+```
+
+In Yii3 templates, `$this` is a `Yiisoft\View\WebView` instance:
+
+```php
+use Yiisoft\Html\Html;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var Post $post
+ */
+
+$this->setTitle($post->getTitle());
+?>
+
+<h1><?= Html::encode($post->getTitle()) ?></h1>
+```
+
+Move controller-specific view logic to the action or to a presenter. Pass only the data a template needs.
+
+See [View](../views/view.md), [View injections](../views/view-injections.md), and
+[Template engines](../views/template-engines.md).
+
+## Assets and client scripts
+
+Yii 1.1 applications often use `CClientScript`, themes, and extension-specific asset publishing:
+
+```php
+Yii::app()->clientScript->registerCssFile('/css/site.css');
+Yii::app()->clientScript->registerScriptFile('/js/site.js');
+```
+
+Yii3 uses asset bundles from `yiisoft/assets`:
+
+```php
+namespace App\Web\Shared\Layout\Main;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class MainAsset extends AssetBundle
+{
+    public ?string $basePath = '@assets/main';
+    public ?string $baseUrl = '@assetsUrl/main';
+    public ?string $sourcePath = '@assetsSource/main';
+
+    public array $css = ['site.css'];
+    public array $js = ['site.js'];
+}
+```
+
+Register bundles through the asset manager in layouts or views.
+
+See [Assets](../views/asset.md) and [Scripts, styles and metatags](../views/script-style-meta.md).
+
+## Models, forms, and validation
+
+Yii 1.1 has `CModel`, `CFormModel`, and `CActiveRecord`. It is common for one model class to contain input data,
+labels, validation rules, database persistence, and business logic.
+
+Yii3 works better when these responsibilities are split:
+
+- form data and labels: `yiisoft/form-model`;
+- validation rules: `yiisoft/validator`;
+- form rendering: `yiisoft/form`;
+- persistence: repositories, `yiisoft/db`, or `yiisoft/active-record`;
+- business workflows: application services.
+
+Yii 1.1 form model:
+
+```php
+class ContactForm extends CFormModel
+{
+    public $name;
+    public $email;
+
+    public function rules()
+    {
+        return [
+            ['name, email', 'required'],
+            ['email', 'email'],
+        ];
+    }
+}
+```
+
+Yii3 form model:
+
+```php
+use Yiisoft\FormModel\FormModel;
+use Yiisoft\Validator\Rule\Email;
+use Yiisoft\Validator\Rule\Required;
+use Yiisoft\Validator\RulesProviderInterface;
+
+final class ContactForm extends FormModel implements RulesProviderInterface
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $email = null,
+    ) {
+    }
+
+    public function getRules(): array
+    {
+        return [
+            'name' => [new Required()],
+            'email' => [new Required(), new Email()],
+        ];
+    }
+}
+```
+
+See [Working with forms](../start/forms.md), [Validating input](https://github.com/yiisoft/validator/blob/master/docs/guide/en/README.md),
+[yiisoft/form](https://github.com/yiisoft/form), and [yiisoft/form-model](https://github.com/yiisoft/form-model).
+
+## Active Record
+
+Yii 1.1 Active Record uses `CActiveRecord::model()` and dynamic attributes:
+
+```php
+class Post extends CActiveRecord
+{
+    public static function model($className = __CLASS__)
+    {
+        return parent::model($className);
+    }
+
+    public function tableName()
+    {
+        return '{{post}}';
+    }
+
+    public function rules()
+    {
+        return [
+            ['title, body', 'required'],
+            ['title', 'length', 'max' => 255],
+        ];
+    }
+}
+```
+
+The incremental Yii3 option is [yiisoft/active-record](https://github.com/yiisoft/active-record):
+
+```php
+use Yiisoft\ActiveRecord\ActiveRecord;
+
+final class Post extends ActiveRecord
+{
+    protected int $id;
+    protected string $title;
+    protected string $body;
+
+    public function tableName(): string
+    {
+        return '{{%post}}';
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title ?? null;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}
+```
+
+Move Yii 1.1 `rules()` to a form model, validator rules, or a service. Keep Active Record focused on persistence:
+table mapping, properties, relations, and database operations.
+
+For more complex applications, consider replacing Active Record-heavy code with repositories and domain objects. That
+is more work initially, but it avoids carrying Yii 1.1 form and persistence coupling into the new application.
+
+See [Working with databases](../start/databases.md), [Migrations](../databases/db-migrations.md), and
+[yiisoft/active-record](https://github.com/yiisoft/active-record).
+
+## Database queries and migrations
+
+Yii 1.1 code may use `CDbCriteria`, `CDbCommand`, `CActiveDataProvider`, and `CGridView` data providers. In Yii3,
+use `yiisoft/db` for database access and query building, and `yiisoft/data` / `yiisoft/yii-dataview` for data readers
+and widgets.
+
+Migrations are not compatible across Yii 1.1, Yii 2.0, and Yii3. For an existing application, create a baseline from
+the current schema and use Yii3 migrations for new changes.
+
+See [Working with databases](../start/databases.md) and [Migrations](../databases/db-migrations.md).
+
+## GridView and data widgets
+
+Yii 1.1 `CGridView` is often configured with `CActiveDataProvider`:
+
+```php
+$this->widget('zii.widgets.grid.CGridView', [
+    'dataProvider' => $dataProvider,
+    'columns' => [
+        'id',
+        'title',
+        [
+            'class' => 'CButtonColumn',
+        ],
+    ],
+]);
+```
+
+Yii3 uses [yiisoft/yii-dataview](https://github.com/yiisoft/yii-dataview):
+
+```php
+use Yiisoft\Data\Reader\ReadableDataInterface;
+use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
+use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
+use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
+use Yiisoft\Yii\DataView\GridView\GridView;
+
+/**
+ * @var ReadableDataInterface $dataReader
+ */
+
+echo GridView::widget()
+    ->dataReader($dataReader)
+    ->columns(
+        new DataColumn(property: 'id'),
+        new DataColumn(property: 'title'),
+        new ActionColumn(
+            urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
+        ),
+    );
+```
+
+Port the old data provider into a query service that returns a data reader. Port filters to validator rules and route
+or query parameters.
+
+See [Using htmx for partial reloads](../../cookbook/using-htmx-for-partial-reloads.md) and
+[yii-dataview GridView docs](https://github.com/yiisoft/yii-dataview/blob/master/docs/en/guide/gridview.md).
+
+## URL management
+
+Yii 1.1:
+
+```php
+echo CHtml::link('View', ['post/view', 'id' => $post->id]);
+$url = Yii::app()->createUrl('post/view', ['id' => $post->id]);
+```
+
+Yii3:
+
+```php
+use Yiisoft\Html\Html;
+use Yiisoft\Router\UrlGeneratorInterface;
+
+$url = $urlGenerator->generate('post/view', ['id' => $post->getId()]);
+
+echo Html::a('View', $url)->render();
+```
+
+Prefer named routes. They make views and GridView action columns easier to port.
+
+See [Routing and URL generation](../runtime/routing.md).
+
+## Filters, access control, and authentication
+
+Yii 1.1 controller filters are controller methods or filter classes:
+
+```php
+public function filters()
+{
+    return [
+        'accessControl',
+    ];
+}
+```
+
+Yii3 uses middleware and focused packages. Move authentication, authorization, CSRF, locale detection, and request
+body parsing out of controllers and into middleware or services.
+
+See [Middleware](../structure/middleware.md), [Authentication](../security/authentication.md), and
+[Authorization](../security/authorization.md).
+
+## Widgets, helpers, and extensions
+
+Yii 1.1 widgets and helpers usually depend on Yii-specific base classes such as `CWidget`, `CHtml`, and extension
+autoloading. In Yii3:
+
+- replace helper calls with `yiisoft/html`, `yiisoft/arrays`, `yiisoft/strings`, or application helpers;
+- replace extensions with Composer packages;
+- port custom widgets to `yiisoft/widget` or plain services/templates;
+- replace jQuery UI and Bootstrap widgets with current frontend packages or Yii3 widget packages where available.
+
+See [Widgets](../views/widget.md).
+
+## Console applications
+
+Yii 1.1 console commands extend `CConsoleCommand`:
+
+```php
+class ReportCommand extends CConsoleCommand
+{
+    public function actionSend()
+    {
+    }
+}
+```
+
+Yii3 console commands are Symfony Console commands configured as services:
+
+```php
+namespace App\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'report/send')]
+final class SendReportCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return Command::SUCCESS;
+    }
+}
+```
+
+See [Console applications](../tutorial/console-applications.md).
+
+## Internationalization
+
+Yii 1.1 message files under `protected/messages` can usually be kept conceptually, but configuration changes. Yii3 uses
+translator packages and explicit message sources. Move message files into the structure expected by the selected
+translator message package and inject translation services where needed.
+
+See [Internationalization](../tutorial/i18n.md).
+
+## What to refactor before porting
+
+These Yii 1.1 refactorings reduce migration risk:
+
+- isolate database queries from controllers;
+- remove direct `Yii::app()` access from domain code;
+- move validation out of Active Record when it describes request input rather than database invariants;
+- replace large controller actions with services;
+- document all routes and URL rules;
+- add tests around the flows you plan to port first;
+- upgrade PHP syntax gradually if the old runtime allows it.
+
+The goal is not to make Yii 1.1 look like Yii3. The goal is to reduce hidden coupling before the code crosses the
+framework boundary.

--- a/src/guide/intro/upgrade-from-v1.md
+++ b/src/guide/intro/upgrade-from-v1.md
@@ -382,23 +382,15 @@ Yii3 form model:
 use Yiisoft\FormModel\FormModel;
 use Yiisoft\Validator\Rule\Email;
 use Yiisoft\Validator\Rule\Required;
-use Yiisoft\Validator\RulesProviderInterface;
 
-final class ContactForm extends FormModel implements RulesProviderInterface
+final class ContactForm extends FormModel
 {
-    public function __construct(
-        public ?string $name = null,
-        public ?string $email = null,
-    ) {
-    }
+    #[Required]
+    public ?string $name = null;
 
-    public function getRules(): array
-    {
-        return [
-            'name' => [new Required()],
-            'email' => [new Required(), new Email()],
-        ];
-    }
+    #[Required]
+    #[Email]
+    public ?string $email = null;
 }
 ```
 
@@ -501,9 +493,9 @@ Yii3 uses [yiisoft/yii-dataview](https://github.com/yiisoft/yii-dataview):
 
 ```php
 use Yiisoft\Data\Reader\ReadableDataInterface;
+use Yiisoft\Yii\DataView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
 use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
-use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\GridView;
 
 /**
@@ -513,8 +505,8 @@ use Yiisoft\Yii\DataView\GridView\GridView;
 echo GridView::widget()
     ->dataReader($dataReader)
     ->columns(
-        new DataColumn(property: 'id'),
-        new DataColumn(property: 'title'),
+        new DataColumn('id'),
+        new DataColumn('title'),
         new ActionColumn(
             urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
         ),

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -4,8 +4,8 @@
 > section.
 
 Yii3 keeps many Yii ideas, but it is not a drop-in replacement for Yii 2.0. It uses PHP 8 features, PSR interfaces,
-dependency injection, explicit package composition, and a different application template. Plan the work as a port to
-a new application, not as a Composer update.
+dependency injection, explicit package composition, and a different application template. Use your Yii 2.0 experience
+to design a new Yii3 application deliberately instead of trying to reproduce the old application structure.
 
 For source applications, compare against:
 
@@ -18,21 +18,26 @@ For the target structure, compare against:
 - [Yii3 guide](../index.md)
 
 Before starting, [check maintenance policy and end-of-life dates for Yii 2.0](https://www.yiiframework.com/release-cycle).
-Keeping a mature Yii 2.0 application on Yii 2.0 can be a valid choice. A Yii3 port is most useful when you want the
+Keeping a mature Yii 2.0 application on Yii 2.0 can be a valid choice. A Yii3 project is most useful when you want the
 new package ecosystem, stricter typing, PSR middleware, and a more explicit architecture.
 
-## Recommended migration strategy
+## Recommended approach
 
-Do the migration in vertical slices:
+Think of the work as building a Yii3 application that is informed by the old one. The old project tells you which
+routes, forms, database tables, business rules, and user workflows matter. The Yii3 project should decide again where
+these responsibilities belong.
+
+Build it in vertical slices:
 
 1. Create a new Yii3 application with `yiisoft/app`.
-2. Configure Composer autoloading and copy only the application code you are actively porting.
-3. Port configuration and routes before controllers.
-4. Port one request flow at a time: route, action, input model, service, persistence, view, assets, tests.
+2. Configure Composer autoloading and add only the code needed for the slice you are building.
+3. Define configuration and routes before writing actions.
+4. Build one request flow at a time: route, action, input model, service, persistence, view, assets, tests.
 5. Keep the Yii 2.0 application running until each flow is verified in Yii3.
 
 Avoid moving the whole directory tree first. Yii3's defaults are intentionally different, and a mechanical copy tends
-to preserve Yii 2.0 service-locator assumptions.
+to preserve Yii 2.0 service-locator assumptions. Prefer small, reviewed decisions over carrying old structure forward
+because it is familiar.
 
 ## PHP requirements
 
@@ -52,8 +57,8 @@ were not common in Yii 2.0 applications:
 - [Constructor property promotion](https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion)
 - [Attributes](https://www.php.net/manual/en/language.attributes.php)
 
-Run static analysis and tests on Yii 2.0 before porting. It is easier to move code that already has explicit types,
-small services, and few implicit `Yii::$app` dependencies.
+Run static analysis and tests on Yii 2.0 before reusing code in Yii3. Code with explicit types, small services, and
+few implicit `Yii::$app` dependencies is easier to understand and easier to place in the new application.
 
 ## Project structure
 
@@ -91,7 +96,7 @@ src/
 tests/
 ```
 
-Typical moves are:
+Typical mappings to consider are:
 
 | Yii 2.0 basic | Yii 2.0 advanced | Yii3 |
 |---------------|------------------|------|
@@ -105,8 +110,8 @@ Typical moves are:
 | `config/*.php` | app and common config files | `config/common`, `config/web`, `config/console`, `config/environments` |
 
 There is no single required layout. The important change is that Yii3 applications should group code by responsibility
-and make dependencies explicit. For an advanced-template migration, treat `frontend` and `backend` as separate web
-contexts. Shared domain code can move to `src/Shared` or to application-specific packages.
+and make dependencies explicit. If you are coming from the advanced template, treat `frontend` and `backend` as separate
+web contexts. Shared domain code can live in `src/Shared` or in application-specific packages.
 
 ## Composer and autoloading
 
@@ -253,9 +258,9 @@ return [
 ];
 ```
 
-When porting a controller, list all Yii 2.0 actions and create named routes for them first. Then port each action to an
-invokable class or a controller-like service. Constructor injection replaces calls to `Yii::$app` and controller
-properties.
+When redesigning a controller flow, list all Yii 2.0 actions and create named routes for the flows you still need.
+Then implement each flow as an invokable class or a controller-like service. Constructor injection replaces calls to
+`Yii::$app` and controller properties.
 
 See [Actions](../structure/action.md), [Middleware](../structure/middleware.md), and
 [Routing and URL generation](../runtime/routing.md).
@@ -300,7 +305,7 @@ final readonly class SavePostAction
 }
 ```
 
-Port request handling code early because it affects forms, filters, REST endpoints, redirects, and tests.
+Design request handling early because it affects forms, filters, REST endpoints, redirects, and tests.
 
 See [Request](../runtime/request.md), [Response](../runtime/response.md), [Sessions](../runtime/sessions.md), and
 [Cookies](../runtime/cookies.md).
@@ -436,13 +441,13 @@ See [Working with forms](../start/forms.md), [Validating input](https://github.c
 
 ## Active Record and persistence
 
-There are two common Yii3 migration paths for Yii 2.0 Active Record classes.
+There are two common Yii3 choices for code that used Yii 2.0 Active Record classes.
 
 The first path is architectural: move business logic to services and domain objects, then use repositories for
 persistence. This is recommended when the Yii 2.0 model contains validation, form scenarios, authorization checks,
 mailing, file uploads, and database access in the same class.
 
-The second path is incremental: port the database model to
+The second path is incremental: represent the database model with
 [yiisoft/active-record](https://github.com/yiisoft/active-record). This is closer to Yii 2.0 and can be significantly
 faster when your Active Record classes mostly describe tables and relations.
 
@@ -534,7 +539,7 @@ $post->setTitle($input->title);
 $post->save();
 ```
 
-When porting, check each Active Record method:
+When deciding what to reuse, check each Active Record method:
 
 - table mapping and relations can usually move to `yiisoft/active-record`;
 - validation should move to `yiisoft/validator`;
@@ -695,7 +700,7 @@ See [Console applications](../tutorial/console-applications.md).
 ## REST APIs
 
 Yii 2.0 REST controllers, serializers, and response formatters do not move directly to Yii3. Start from PSR-7
-responses and explicit routing. Port one resource at a time:
+responses and explicit routing. Build one resource at a time:
 
 1. define routes for collection and item operations;
 2. inject request, persistence, serializer, and response factory dependencies;
@@ -708,7 +713,7 @@ See [REST APIs](../index.md#rest-apis), [Response](../runtime/response.md), and
 
 ## Testing
 
-Do not postpone tests until the full migration is done. For each ported request flow, add:
+Do not postpone tests until the whole Yii3 application is done. For each new request flow, add:
 
 - unit tests for services and validators;
 - functional tests for actions and middleware;
@@ -721,9 +726,9 @@ component arrays.
 See [Testing overview](../testing/overview.md), [Unit tests](../testing/unit.md),
 [Functional tests](../testing/functional.md), and [End-to-end tests](../testing/end-to-end.md).
 
-## Preliminary refactoring in Yii 2.0
+## Refactoring Yii 2.0 code before reusing it
 
-These changes are useful even before the Yii3 port:
+These changes are useful even if the old application stays on Yii 2.0 for a while:
 
 - Replace `Yii::$app` access in domain code with constructor arguments.
 - Move queries out of controllers and views into repositories or query services.
@@ -731,6 +736,7 @@ These changes are useful even before the Yii3 port:
 - Separate form models from persistence models.
 - Add return types and parameter types.
 - Replace route arrays scattered in views with named route constants or helper methods.
-- Add tests around each flow before changing framework code.
+- Add tests around each flow before rebuilding it in Yii3.
 
-The less framework state your Yii 2.0 code assumes, the easier it is to port to Yii3.
+The less framework state your Yii 2.0 code assumes, the easier it is to understand what should be reused and what
+should be redesigned for Yii3.

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -173,7 +173,7 @@ Move configuration in groups:
 - route definitions to `config/common/routes.php`;
 - shared service definitions to `config/common/di/*.php`;
 - web-only service definitions to `config/web/di/*.php`;
-- console parameters and commands to `config/console`;
+- console parameters and commands to `config/console/*.php`;
 - shared parameters to `config/common/params.php`;
 - environment overrides to `config/environments`.
 

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -171,10 +171,15 @@ Move configuration in groups:
 
 - aliases to `config/common/aliases.php`;
 - route definitions to `config/common/routes.php`;
-- web-only service definitions to `config/web`;
-- console-only service definitions to `config/console`;
+- shared service definitions to `config/common/di/*.php`;
+- web-only service definitions to `config/web/di/*.php`;
+- console parameters and commands to `config/console`;
 - shared parameters to `config/common/params.php`;
 - environment overrides to `config/environments`.
+
+The default template's `di-console` group reuses shared definitions from `config/common/di/*.php`. If you need
+console-only container definitions, add the corresponding files to the `di-console` group in `config/configuration.php`
+and rebuild the merge plan.
 
 See [Configuration](../concept/configuration.md), [Aliases](../concept/aliases.md), and
 [Dependency injection container](../concept/di-container.md).
@@ -708,8 +713,8 @@ responses and explicit routing. Build one resource at a time:
 4. return JSON responses through Yii3 response helpers or PSR-7 factories;
 5. move authentication and rate limiting to middleware.
 
-See [REST APIs](../index.md#rest-apis), [Response](../runtime/response.md), and
-[Authentication](../security/authentication.md).
+See [Response](../runtime/response.md), [Authentication](../security/authentication.md), and
+[Authorization](../security/authorization.md).
 
 ## Testing
 

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -570,7 +570,6 @@ fluent widget configuration:
 use Yiisoft\Data\Reader\ReadableDataInterface;
 use Yiisoft\Yii\DataView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
-use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
 use Yiisoft\Yii\DataView\GridView\GridView;
 
 /**
@@ -583,9 +582,7 @@ echo GridView::widget()
         new DataColumn('id'),
         new DataColumn('title', header: 'Title'),
         new DataColumn('created_at', header: 'Created'),
-        new ActionColumn(
-            urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
-        ),
+        new ActionColumn(),
     );
 ```
 

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -417,23 +417,15 @@ Yii3 separates these concerns. Use `yiisoft/form-model` for form data and metada
 use Yiisoft\FormModel\FormModel;
 use Yiisoft\Validator\Rule\Email;
 use Yiisoft\Validator\Rule\Required;
-use Yiisoft\Validator\RulesProviderInterface;
 
-final class ContactForm extends FormModel implements RulesProviderInterface
+final class ContactForm extends FormModel
 {
-    public function __construct(
-        public ?string $name = null,
-        public ?string $email = null,
-    ) {
-    }
+    #[Required]
+    public ?string $name = null;
 
-    public function getRules(): array
-    {
-        return [
-            'name' => [new Required()],
-            'email' => [new Required(), new Email()],
-        ];
-    }
+    #[Required]
+    #[Email]
+    public ?string $email = null;
 }
 ```
 
@@ -516,23 +508,15 @@ form models, command objects, or services:
 use Yiisoft\FormModel\FormModel;
 use Yiisoft\Validator\Rule\Length;
 use Yiisoft\Validator\Rule\Required;
-use Yiisoft\Validator\RulesProviderInterface;
 
-final class PostInput extends FormModel implements RulesProviderInterface
+final class PostInput extends FormModel
 {
-    public function __construct(
-        public ?string $title = null,
-        public ?string $body = null,
-    ) {
-    }
+    #[Required]
+    #[Length(max: 255)]
+    public ?string $title = null;
 
-    public function getRules(): array
-    {
-        return [
-            'title' => [new Required(), new Length(max: 255)],
-            'body' => [new Required()],
-        ];
-    }
+    #[Required]
+    public ?string $body = null;
 }
 ```
 
@@ -584,9 +568,9 @@ fluent widget configuration:
 
 ```php
 use Yiisoft\Data\Reader\ReadableDataInterface;
+use Yiisoft\Yii\DataView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
 use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
-use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\GridView;
 
 /**
@@ -596,9 +580,9 @@ use Yiisoft\Yii\DataView\GridView\GridView;
 echo GridView::widget()
     ->dataReader($dataReader)
     ->columns(
-        new DataColumn(property: 'id'),
-        new DataColumn(property: 'title', header: 'Title'),
-        new DataColumn(property: 'created_at', header: 'Created'),
+        new DataColumn('id'),
+        new DataColumn('title', header: 'Title'),
+        new DataColumn('created_at', header: 'Created'),
         new ActionColumn(
             urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
         ),
@@ -618,8 +602,8 @@ echo GridView::widget()
     ->urlParameterProvider(new UrlParameterProvider($currentRoute))
     ->urlCreator(new UrlCreator($urlGenerator))
     ->columns(
-        new DataColumn(property: 'id'),
-        new DataColumn(property: 'title'),
+        new DataColumn('id'),
+        new DataColumn('title'),
         new ActionColumn(
             urlCreator: new ActionColumnUrlCreator($urlGenerator, $currentRoute),
             urlConfig: new ActionColumnUrlConfig(baseRouteName: 'post'),

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -3,13 +3,41 @@
 > If you haven't used Yii 2.0, you can skip this section and get directly to "[getting started](../start/prerequisites.md)"
 > section.
 
-While sharing some common ideas and values, Yii3 is conceptually different from Yii 2.0. There is no easy upgrade
-path, so first [check maintenance policy and end-of-life dates for Yii 2.0](https://www.yiiframework.com/release-cycle)
-and consider starting new projects on Yii3 while keeping existing ones on Yii 2.0.
+Yii3 keeps many Yii ideas, but it is not a drop-in replacement for Yii 2.0. It uses PHP 8 features, PSR interfaces,
+dependency injection, explicit package composition, and a different application template. Plan the work as a port to
+a new application, not as a Composer update.
+
+For source applications, compare against:
+
+- [yiisoft/yii2-app-basic](https://github.com/yiisoft/yii2-app-basic)
+- [yiisoft/yii2-app-advanced](https://github.com/yiisoft/yii2-app-advanced)
+
+For the target structure, compare against:
+
+- [yiisoft/app](https://github.com/yiisoft/app)
+- [Yii3 guide](../index.md)
+
+Before starting, [check maintenance policy and end-of-life dates for Yii 2.0](https://www.yiiframework.com/release-cycle).
+Keeping a mature Yii 2.0 application on Yii 2.0 can be a valid choice. A Yii3 port is most useful when you want the
+new package ecosystem, stricter typing, PSR middleware, and a more explicit architecture.
+
+## Recommended migration strategy
+
+Do the migration in vertical slices:
+
+1. Create a new Yii3 application with `yiisoft/app`.
+2. Configure Composer autoloading and copy only the application code you are actively porting.
+3. Port configuration and routes before controllers.
+4. Port one request flow at a time: route, action, input model, service, persistence, view, assets, tests.
+5. Keep the Yii 2.0 application running until each flow is verified in Yii3.
+
+Avoid moving the whole directory tree first. Yii3's defaults are intentionally different, and a mechanical copy tends
+to preserve Yii 2.0 service-locator assumptions.
 
 ## PHP requirements
 
-Yii3 requires PHP 8.2 or above. As a result, there are language features used that weren't used in Yii 2.0:
+Yii3 application templates require PHP 8.2 or above. As a result, application code can use language features that
+were not common in Yii 2.0 applications:
 
 - [Type declarations](https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration)
 - [Return type declarations](https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration)
@@ -24,77 +52,685 @@ Yii3 requires PHP 8.2 or above. As a result, there are language features used th
 - [Constructor property promotion](https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion)
 - [Attributes](https://www.php.net/manual/en/language.attributes.php)
 
-## Preliminary refactoring
+Run static analysis and tests on Yii 2.0 before porting. It is easier to move code that already has explicit types,
+small services, and few implicit `Yii::$app` dependencies.
 
-It's a good idea to refactor your Yii 2.0 project before porting it to Yii3. That would both make porting easier
-and benefit the project in question while it's not moved to Yii3 yet.
+## Project structure
 
-### Use DI instead of the service locator
+Yii 2.0 applications commonly keep framework roles in top-level directories:
 
-Since Yii3 is forcing you to inject dependencies, it's a good idea to prepare and switch from using
-service locator (`Yii::$app->`) to [DI container](https://www.yiiframework.com/doc/guide/2.0/en/concept-di-container).
+```text
+assets/
+commands/
+config/
+controllers/
+models/
+runtime/
+views/
+web/
+widgets/
+```
 
-If usage of DI container is problematic for whatever reason, consider moving all calls to `Yii::$app->` to controller
-actions and widgets and passing dependencies manually from a controller to what needs them.
+The Yii 2.0 advanced template splits the same roles by application:
 
-See [Dependency injection and container](../concept/di-container.md) for an explanation of the idea.
+```text
+backend/
+common/
+console/
+frontend/
+```
 
-### Introduce repositories for getting data
+The current Yii3 application template is organized around source code, configuration, public files, and runtime files:
 
-Since Active Record isn't the only way to work with a database in Yii3, consider introducing repositories that would
-hide details of getting data and gather them in a single place. You can later redo it: 
+```text
+assets/
+config/
+public/
+runtime/
+src/
+tests/
+```
 
-```php
-final readonly class PostRepository
+Typical moves are:
+
+| Yii 2.0 basic | Yii 2.0 advanced | Yii3 |
+|---------------|------------------|------|
+| `controllers/` | `frontend/controllers/`, `backend/controllers/` | `src/Web/*/Action.php` or controller-like classes |
+| `models/` | `common/models/`, app-specific models | `src/Domain`, `src/Shared`, `src/Web/*`, or `src/Db` by responsibility |
+| `views/` | `frontend/views/`, `backend/views/` | templates near the feature, for example `src/Web/HomePage/template.php` |
+| `views/layouts/` | app layout directories | layout classes/templates, for example `src/Web/Shared/Layout/Main` |
+| `assets/` | app asset bundles | `assets/` for source files and `src/Web/.../*Asset.php` for bundles |
+| `web/` | `frontend/web/`, `backend/web/` | `public/` |
+| `commands/` | `console/controllers/` | `src/Console/*Command.php` |
+| `config/*.php` | app and common config files | `config/common`, `config/web`, `config/console`, `config/environments` |
+
+There is no single required layout. The important change is that Yii3 applications should group code by responsibility
+and make dependencies explicit. For an advanced-template migration, treat `frontend` and `backend` as separate web
+contexts. Shared domain code can move to `src/Shared` or to application-specific packages.
+
+## Composer and autoloading
+
+Yii 2.0 applications usually require `vendor/autoload.php` and `vendor/yiisoft/yii2/Yii.php` in `web/index.php`.
+Yii3 applications require only Composer's autoloader and application bootstrap code.
+
+Configure your application namespace with PSR-4:
+
+```json
 {
-    public function getArchive()
-    {
-        // ...
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
     }
-    
-    public function getTop10ForFrontPage()
-    {
-        // ...
-    }
-
 }
 ```
 
-### Separate domain layer from infrastructure
+Then rebuild Composer autoload files:
 
-In case you have a rich complicated domain, it's a good idea to separate it from infrastructure provided by a framework
-that's all the business logic has to go to framework-independent classes.
+```shell
+composer dump-autoload
+```
 
-### Move more into components
+Install Yii3 packages intentionally. Yii3 is split into focused packages, so features such as database access, forms,
+validation, assets, data widgets, authentication, and caching are separate Composer dependencies.
 
-Yii3 services are conceptually similar to Yii 2.0 components, so it's a good idea to move reusable parts of your application
-into components.
+## Configuration and services
 
-## Things to learn
+In Yii 2.0, many services are configured as application components and accessed through the service locator:
 
-### Docker
+```php
+$cache = Yii::$app->cache;
+$db = Yii::$app->db;
+$url = Yii::$app->urlManager->createUrl(['post/view', 'id' => $id]);
+```
 
-Default application templates are using [Docker](https://www.docker.com/get-started/) to run application.
-It's a good idea to learn how to use it and use it for your own projects since it provides a lot of benefits:
+In Yii3, services are configured for the container and injected where they are needed:
 
-1. Exactly the same environment as in production.
-2. No need to install anything except Docker itself.
-3. Environment is per application, not per server.
+```php
+use Psr\SimpleCache\CacheInterface;
+use Yiisoft\Db\Connection\ConnectionInterface;
+use Yiisoft\Router\UrlGeneratorInterface;
 
-### Environment variables
+final readonly class PostService
+{
+    public function __construct(
+        private ConnectionInterface $db,
+        private CacheInterface $cache,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+}
+```
 
-Yii3 application templates are using [environment variables](https://en.wikipedia.org/wiki/Environment_variable)
-to configure parts of the application. The concept is [very handy for Dockerized applications](https://12factor.net/)
-but might be alien to users of Yii 1.1 and Yii 2.0.
+Move configuration in groups:
 
-### Actions
+- aliases to `config/common/aliases.php`;
+- route definitions to `config/common/routes.php`;
+- web-only service definitions to `config/web`;
+- console-only service definitions to `config/console`;
+- shared parameters to `config/common/params.php`;
+- environment overrides to `config/environments`.
 
-Unlike Yii 2.0, Yii3 does not require controllers. Instead, it uses [actions](../structure/action.md), which
-are any callables. You can organize these into controllers similar to Yii 2, but it's not required.
+See [Configuration](../concept/configuration.md), [Aliases](../concept/aliases.md), and
+[Dependency injection container](../concept/di-container.md).
 
-### Application structure
+## Entry script and bootstrap
 
-Suggested Yii3 application structure is different from Yii 2.0. 
-It's described in [application structure](../structure/overview.md).
+A Yii 2.0 basic entry script commonly creates the application directly:
 
-Despite that, Yii3 is flexible, so it's still possible to use a structure similar to Yii 2.0 with Yii3.
+```php
+defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', 'dev');
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
+
+$config = require __DIR__ . '/../config/web.php';
+
+(new yii\web\Application($config))->run();
+```
+
+In Yii3, use the application template entry script as the source of truth. It loads Composer and bootstraps the
+configured application runner. Avoid recreating the old `yii\web\Application` pattern in `public/index.php`; put
+configuration in config files and dependencies in the container.
+
+See [Entry scripts](../structure/entry-script.md) and [Application workflow](../start/workflow.md).
+
+## Controllers, actions, and routing
+
+Yii 2.0 routes usually point to controller action methods:
+
+```php
+namespace app\controllers;
+
+use yii\web\Controller;
+
+final class SiteController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+}
+```
+
+Yii3 does not require controller base classes. The current application template uses invokable action classes:
+
+```php
+namespace App\Web\HomePage;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
+
+final readonly class Action
+{
+    public function __construct(
+        private WebViewRenderer $viewRenderer,
+    ) {
+    }
+
+    public function __invoke(): ResponseInterface
+    {
+        return $this->viewRenderer->render(__DIR__ . '/template');
+    }
+}
+```
+
+Routes are explicit:
+
+```php
+use App\Web;
+use Yiisoft\Router\Group;
+use Yiisoft\Router\Route;
+
+return [
+    Group::create()
+        ->routes(
+            Route::get('/')
+                ->action(Web\HomePage\Action::class)
+                ->name('home'),
+        ),
+];
+```
+
+When porting a controller, list all Yii 2.0 actions and create named routes for them first. Then port each action to an
+invokable class or a controller-like service. Constructor injection replaces calls to `Yii::$app` and controller
+properties.
+
+See [Actions](../structure/action.md), [Middleware](../structure/middleware.md), and
+[Routing and URL generation](../runtime/routing.md).
+
+## Requests, responses, sessions, and cookies
+
+Yii 2.0 actions often read request data and write response data through application components:
+
+```php
+$id = Yii::$app->request->get('id');
+Yii::$app->session->setFlash('success', 'Saved.');
+
+return $this->redirect(['post/view', 'id' => $id]);
+```
+
+Yii3 uses PSR-7 request and response objects and injectable services:
+
+```php
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Yiisoft\Http\Status;
+use Yiisoft\Router\UrlGeneratorInterface;
+
+final readonly class SavePostAction
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        $id = (int) ($request->getQueryParams()['id'] ?? 0);
+        $url = $this->urlGenerator->generate('post/view', ['id' => $id]);
+
+        return $this->responseFactory
+            ->createResponse(Status::SEE_OTHER)
+            ->withHeader('Location', $url);
+    }
+}
+```
+
+Port request handling code early because it affects forms, filters, REST endpoints, redirects, and tests.
+
+See [Request](../runtime/request.md), [Response](../runtime/response.md), [Sessions](../runtime/sessions.md), and
+[Cookies](../runtime/cookies.md).
+
+## Views, layouts, assets, and URLs
+
+In Yii 2.0, controller rendering finds files under `views/{controller}` and layouts under `views/layouts`:
+
+```php
+return $this->render('view', [
+    'model' => $model,
+]);
+```
+
+In Yii3, the template path is explicit in the action:
+
+```php
+return $this->viewRenderer->render(__DIR__ . '/view', [
+    'post' => $post,
+]);
+```
+
+A Yii3 template receives a `Yiisoft\View\WebView` instance as `$this`:
+
+```php
+use App\Shared\ApplicationParams;
+use Yiisoft\Html\Html;
+use Yiisoft\View\WebView;
+
+/**
+ * @var WebView $this
+ * @var ApplicationParams $applicationParams
+ * @var string $title
+ */
+
+$this->setTitle($title . ' - ' . $applicationParams->name);
+?>
+
+<h1><?= Html::encode($title) ?></h1>
+```
+
+Asset bundles move from `yii\web\AssetBundle` to `Yiisoft\Assets\AssetBundle`:
+
+```php
+namespace App\Web\Shared\Layout\Main;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class MainAsset extends AssetBundle
+{
+    public ?string $basePath = '@assets/main';
+    public ?string $baseUrl = '@assetsUrl/main';
+    public ?string $sourcePath = '@assetsSource/main';
+
+    public array $css = [
+        'site.css',
+    ];
+}
+```
+
+Register assets in a layout or view via the asset manager:
+
+```php
+$assetManager->register(MainAsset::class);
+
+$this->addCssFiles($assetManager->getCssFiles());
+$this->addJsFiles($assetManager->getJsFiles());
+```
+
+Replace `yii\helpers\Url` and `Yii::$app->urlManager` usage with named routes and
+`Yiisoft\Router\UrlGeneratorInterface`:
+
+```php
+$url = $urlGenerator->generate('post/view', ['id' => $post->getId()]);
+```
+
+See [View](../views/view.md), [Assets](../views/asset.md), [Scripts, styles and metatags](../views/script-style-meta.md),
+and [Template engines](../views/template-engines.md).
+
+## Forms and validation
+
+Yii 2.0 frequently combines form data, labels, validation, and sometimes persistence in a `yii\base\Model` or
+`yii\db\ActiveRecord` class:
+
+```php
+final class ContactForm extends \yii\base\Model
+{
+    public $name;
+    public $email;
+
+    public function rules(): array
+    {
+        return [
+            [['name', 'email'], 'required'],
+            ['email', 'email'],
+        ];
+    }
+}
+```
+
+Yii3 separates these concerns. Use `yiisoft/form-model` for form data and metadata, and `yiisoft/validator` for rules:
+
+```php
+use Yiisoft\FormModel\FormModel;
+use Yiisoft\Validator\Rule\Email;
+use Yiisoft\Validator\Rule\Required;
+use Yiisoft\Validator\RulesProviderInterface;
+
+final class ContactForm extends FormModel implements RulesProviderInterface
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $email = null,
+    ) {
+    }
+
+    public function getRules(): array
+    {
+        return [
+            'name' => [new Required()],
+            'email' => [new Required(), new Email()],
+        ];
+    }
+}
+```
+
+For form rendering, replace `yii\widgets\ActiveForm` with `yiisoft/form` fields and form model integration. For input
+hydration, prefer the form-model and hydrator packages instead of mass-assigning arbitrary request data to persistence
+objects.
+
+See [Working with forms](../start/forms.md), [Validating input](https://github.com/yiisoft/validator/blob/master/docs/guide/en/README.md),
+[yiisoft/form](https://github.com/yiisoft/form), and [yiisoft/form-model](https://github.com/yiisoft/form-model).
+
+## Active Record and persistence
+
+There are two common Yii3 migration paths for Yii 2.0 Active Record classes.
+
+The first path is architectural: move business logic to services and domain objects, then use repositories for
+persistence. This is recommended when the Yii 2.0 model contains validation, form scenarios, authorization checks,
+mailing, file uploads, and database access in the same class.
+
+The second path is incremental: port the database model to
+[yiisoft/active-record](https://github.com/yiisoft/active-record). This is closer to Yii 2.0 and can be significantly
+faster when your Active Record classes mostly describe tables and relations.
+
+Yii 2.0:
+
+```php
+final class Post extends \yii\db\ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return '{{%post}}';
+    }
+
+    public function rules(): array
+    {
+        return [
+            [['title', 'body'], 'required'],
+            ['title', 'string', 'max' => 255],
+        ];
+    }
+}
+```
+
+Yii3 Active Record:
+
+```php
+use Yiisoft\ActiveRecord\ActiveRecord;
+
+final class Post extends ActiveRecord
+{
+    protected int $id;
+    protected string $title;
+    protected string $body;
+
+    public function tableName(): string
+    {
+        return '{{%post}}';
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id ?? null;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title ?? null;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}
+```
+
+Do not move Yii 2.0 `rules()` directly into the Active Record class. In Yii3, validation belongs to validator rules,
+form models, command objects, or services:
+
+```php
+use Yiisoft\FormModel\FormModel;
+use Yiisoft\Validator\Rule\Length;
+use Yiisoft\Validator\Rule\Required;
+use Yiisoft\Validator\RulesProviderInterface;
+
+final class PostInput extends FormModel implements RulesProviderInterface
+{
+    public function __construct(
+        public ?string $title = null,
+        public ?string $body = null,
+    ) {
+    }
+
+    public function getRules(): array
+    {
+        return [
+            'title' => [new Required(), new Length(max: 255)],
+            'body' => [new Required()],
+        ];
+    }
+}
+```
+
+Then copy validated data into the record or pass it to an application service:
+
+```php
+$post = new Post();
+$post->setTitle($input->title);
+$post->save();
+```
+
+When porting, check each Active Record method:
+
+- table mapping and relations can usually move to `yiisoft/active-record`;
+- validation should move to `yiisoft/validator`;
+- form labels and hints should move to `yiisoft/form-model`;
+- search models should become query/data-reader services;
+- business workflows should become services;
+- events should use PSR-14 events or package-specific events;
+- direct `Yii::$app->db` usage should become injected database dependencies.
+
+Yii 2.0 migrations and Yii3 `yiisoft/db-migration` migrations are not compatible. Start a new migration history or
+create structure dumps for the current schema, then use Yii3 migrations for future schema changes.
+
+See [Working with databases](../start/databases.md), [Migrations](../databases/db-migrations.md), and
+[yiisoft/active-record](https://github.com/yiisoft/active-record).
+
+## GridView and data widgets
+
+Yii 2.0 `GridView` is commonly used with `ActiveDataProvider`:
+
+```php
+use yii\grid\GridView;
+
+echo GridView::widget([
+    'dataProvider' => $dataProvider,
+    'filterModel' => $searchModel,
+    'columns' => [
+        'id',
+        'title',
+        'created_at:datetime',
+        ['class' => 'yii\grid\ActionColumn'],
+    ],
+]);
+```
+
+Yii3 uses [yiisoft/yii-dataview](https://github.com/yiisoft/yii-dataview). It renders data from a data reader and uses
+fluent widget configuration:
+
+```php
+use Yiisoft\Data\Reader\ReadableDataInterface;
+use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
+use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
+use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
+use Yiisoft\Yii\DataView\GridView\GridView;
+
+/**
+ * @var ReadableDataInterface $dataReader
+ */
+
+echo GridView::widget()
+    ->dataReader($dataReader)
+    ->columns(
+        new DataColumn(property: 'id'),
+        new DataColumn(property: 'title', header: 'Title'),
+        new DataColumn(property: 'created_at', header: 'Created'),
+        new ActionColumn(
+            urlCreator: static fn(string $action, DataContext $context): string => "/post/$action/" . $context->key,
+        ),
+    );
+```
+
+For sorting, pagination, filtering, and action URLs, wire the widget to Yii Router:
+
+```php
+use Yiisoft\Yii\DataView\YiiRouter\ActionColumnUrlConfig;
+use Yiisoft\Yii\DataView\YiiRouter\ActionColumnUrlCreator;
+use Yiisoft\Yii\DataView\YiiRouter\UrlCreator;
+use Yiisoft\Yii\DataView\YiiRouter\UrlParameterProvider;
+
+echo GridView::widget()
+    ->dataReader($dataReader)
+    ->urlParameterProvider(new UrlParameterProvider($currentRoute))
+    ->urlCreator(new UrlCreator($urlGenerator))
+    ->columns(
+        new DataColumn(property: 'id'),
+        new DataColumn(property: 'title'),
+        new ActionColumn(
+            urlCreator: new ActionColumnUrlCreator($urlGenerator, $currentRoute),
+            urlConfig: new ActionColumnUrlConfig(baseRouteName: 'post'),
+        ),
+    );
+```
+
+A Yii 2.0 search model usually becomes a query service that:
+
+1. reads filter and sort parameters from the request;
+2. validates them with `yiisoft/validator`;
+3. builds a database query or repository query;
+4. exposes a data reader to GridView.
+
+See [Using htmx for partial reloads](../../cookbook/using-htmx-for-partial-reloads.md) for a complete Yii3 GridView
+workflow and [yii-dataview GridView docs](https://github.com/yiisoft/yii-dataview/blob/master/docs/en/guide/gridview.md).
+
+## Filters, middleware, and access control
+
+Yii 2.0 controller filters and behaviors usually look like this:
+
+```php
+public function behaviors(): array
+{
+    return [
+        'access' => [
+            'class' => \yii\filters\AccessControl::class,
+            'rules' => [
+                ['allow' => true, 'roles' => ['@']],
+            ],
+        ],
+    ];
+}
+```
+
+In Yii3, request processing is middleware-based. Move cross-cutting concerns such as authentication, authorization,
+body parsing, locale negotiation, CSRF checks, and error handling to middleware or dedicated services. Keep actions
+focused on the request flow they implement.
+
+See [Middleware](../structure/middleware.md), [Authentication](../security/authentication.md), and
+[Authorization](../security/authorization.md).
+
+## Console commands
+
+Yii 2.0 console commands extend `yii\console\Controller`:
+
+```php
+final class ReportController extends \yii\console\Controller
+{
+    public function actionSend(): int
+    {
+        // ...
+        return self::EXIT_CODE_NORMAL;
+    }
+}
+```
+
+Yii3 console commands are services in `src/Console`:
+
+```php
+namespace App\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'report/send')]
+final class SendReportCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // ...
+        return Command::SUCCESS;
+    }
+}
+```
+
+Move command dependencies to constructor injection and register commands in console configuration.
+
+See [Console applications](../tutorial/console-applications.md).
+
+## REST APIs
+
+Yii 2.0 REST controllers, serializers, and response formatters do not move directly to Yii3. Start from PSR-7
+responses and explicit routing. Port one resource at a time:
+
+1. define routes for collection and item operations;
+2. inject request, persistence, serializer, and response factory dependencies;
+3. validate input with `yiisoft/validator`;
+4. return JSON responses through Yii3 response helpers or PSR-7 factories;
+5. move authentication and rate limiting to middleware.
+
+See [REST APIs](../index.md#rest-apis), [Response](../runtime/response.md), and
+[Authentication](../security/authentication.md).
+
+## Testing
+
+Do not postpone tests until the full migration is done. For each ported request flow, add:
+
+- unit tests for services and validators;
+- functional tests for actions and middleware;
+- end-to-end tests for critical browser flows;
+- static analysis for stricter type checks.
+
+Yii3 code is more explicit, so tests should assert services directly instead of constructing large application
+component arrays.
+
+See [Testing overview](../testing/overview.md), [Unit tests](../testing/unit.md),
+[Functional tests](../testing/functional.md), and [End-to-end tests](../testing/end-to-end.md).
+
+## Preliminary refactoring in Yii 2.0
+
+These changes are useful even before the Yii3 port:
+
+- Replace `Yii::$app` access in domain code with constructor arguments.
+- Move queries out of controllers and views into repositories or query services.
+- Move business workflows out of Active Record classes.
+- Separate form models from persistence models.
+- Add return types and parameter types.
+- Replace route arrays scattered in views with named route constants or helper methods.
+- Add tests around each flow before changing framework code.
+
+The less framework state your Yii 2.0 code assumes, the easier it is to port to Yii3.

--- a/src/guide/intro/upgrade-from-v2.md
+++ b/src/guide/intro/upgrade-from-v2.md
@@ -39,6 +39,60 @@ Avoid moving the whole directory tree first. Yii3's defaults are intentionally d
 to preserve Yii 2.0 service-locator assumptions. Prefer small, reviewed decisions over carrying old structure forward
 because it is familiar.
 
+## Prepare the Yii 2.0 application
+
+Useful preparation can happen before the Yii3 application is ready. These refactorings improve the Yii 2.0 project
+itself and make the later rewrite less dependent on hidden framework state:
+
+- Replace `Yii::$app` access in reusable code with constructor arguments where practical. If a full dependency
+  injection refactoring is too large, keep `Yii::$app` calls near controllers and widgets, then pass values and
+  services to lower-level code explicitly.
+- Introduce repositories or query services for database reads that are currently scattered across controllers, views,
+  widgets, and Active Record methods. Yii3 does not require Active Record for persistence, so a repository boundary
+  gives you a natural place to change the implementation later.
+- Separate business rules from framework infrastructure. Domain code that does not extend Yii classes, read global
+  application state, or render views is much easier to reuse or rewrite.
+- Move reusable behavior into Yii 2.0 components or services instead of keeping it inside large controllers and Active
+  Record classes. Yii3 services are configured and injected differently, but the responsibility boundary is similar.
+- Add tests around routes and workflows you plan to rebuild first. They become the executable specification for the
+  Yii3 slice.
+
+For example, instead of reading post archive data directly from several controllers or widgets, create a small service
+that describes the application need:
+
+```php
+final class PostRepository
+{
+    public function getArchive(): array
+    {
+        // ...
+    }
+
+    public function getTopForFrontPage(int $limit = 10): array
+    {
+        // ...
+    }
+}
+```
+
+The Yii3 implementation may still use Active Record, or it may use `yiisoft/db` queries. The important point is that
+controllers and views no longer need to know that detail.
+
+## Things to learn before starting
+
+Some Yii3 application-template choices are worth learning before you start moving features:
+
+- [Docker](https://www.docker.com/get-started/). The default Yii3 application template includes Docker configuration.
+  Using it gives each application its own repeatable environment and reduces differences between local development and
+  production.
+- [Environment variables](https://en.wikipedia.org/wiki/Environment_variable). Yii3 templates commonly use them for
+  environment-specific settings and secrets, especially in Docker-based deployments. This follows the same idea as
+  [12-factor app configuration](https://12factor.net/config).
+- [Actions](../structure/action.md). Yii3 does not require controller inheritance. A route can point to any callable,
+  and the default template uses invokable action classes.
+- [Application structure](../structure/overview.md). Yii3's default structure is different from Yii 2.0. The structure
+  is flexible, but start with the Yii3 template and change it only when the application needs it.
+
 ## PHP requirements
 
 Yii3 application templates require PHP 8.2 or above. As a result, application code can use language features that


### PR DESCRIPTION
- expand the Yii 2.0 to Yii3 migration guide with practical migration topics and examples
- add a Yii 1.1 to Yii3 migration guide
- add the new guide to the English Markdown TOC and VitePress sidebar

Closes #110