### PR TITLE
Fix #360: Add package design guide

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -89,7 +89,8 @@ export default {
                                 {text: 'Middleware', link: '/guide/structure/middleware'},
                                 {text: 'Domain', link: '/guide/structure/domain'},
                                 {text: 'Service', link: '/guide/structure/service'},
-                                {text: 'Package', link: '/guide/structure/package'}
+                                {text: 'Package', link: '/guide/structure/package'},
+                                {text: 'Designing Packages', link: '/guide/structure/designing-packages'}
                             ]
                         },
                         {

--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -88,7 +88,12 @@ export default {
                                 {text: 'Action', link: '/guide/structure/action'},
                                 {text: 'Middleware', link: '/guide/structure/middleware'},
                                 {text: 'Domain', link: '/guide/structure/domain'},
-                                {text: 'Service', link: '/guide/structure/service'},
+                                {text: 'Service', link: '/guide/structure/service'}
+                            ]
+                        },
+                        {
+                            text: 'Packages',
+                            items: [
                                 {text: 'Package', link: '/guide/structure/package'},
                                 {text: 'Designing Packages', link: '/guide/structure/designing-packages'}
                             ]

--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -94,7 +94,7 @@ export default {
                         {
                             text: 'Packages',
                             items: [
-                                {text: 'Package', link: '/guide/structure/package'},
+                                {text: 'Using Packages', link: '/guide/structure/package'},
                                 {text: 'Designing Packages', link: '/guide/structure/designing-packages'}
                             ]
                         },

--- a/src/guide/concept/configuration.md
+++ b/src/guide/concept/configuration.md
@@ -202,7 +202,7 @@ For convenience, there is a naming convention for custom string keys:
 ### Service providers
 
 As an alternative to registering dependencies directly, you can use service providers. A service provider is a class
-that receives configured options and registers services within the container.
+that returns a reusable set of container definitions and extensions.
 
 The default template exposes three config groups for service providers: `di-providers`, `di-providers-web`, and
 `di-providers-console`. In the template they are initialized as empty arrays in `config/configuration.php`, and you can
@@ -211,15 +211,15 @@ later populate them inline or switch them to load values from files.
 Prefer direct container configuration for application services with a simple definition: a class name, an interface
 implementation, constructor arguments from `$params`, or a closure that creates a single service.
 
-Use a service provider when the registration itself is a unit of code:
+Use a service provider when the registration itself is a reusable unit:
 
-- A package registers several related services, aliases, or decorators.
+- A package registers several related services, aliases, or extensions.
 - A service registration also needs supporting definitions.
 - The same registration should be reused in several applications.
-- Registration depends on runtime checks, optional classes, or environment-specific decisions.
+- Registration depends on optional classes or environment-specific decisions.
 
 Use a factory class when construction logic belongs to one service. A factory returns an object. A service provider
-registers definitions in the container.
+returns definitions for several related services.
 
 ```php
 /* @var array $params */
@@ -232,24 +232,18 @@ use App\Provider\MiddlewareProvider;
 return [
     // ...
     'yiisoft/yii-web/middleware' => MiddlewareProvider::class,
-    'yiisoft/cache/cache' =>  [
-        'class' => CacheProvider::class,
-        '__construct()' => [
-            $params['yiisoft/cache-file']['file-cache']['path'],
-        ],
-    ],
+    'yiisoft/cache/cache' => new CacheProvider($params['yiisoft/cache-file']['file-cache']['path']),
     // ...
 ];
 ```
 
 In this config keys are provider names. By convention these are `vendor/package-name/provider-name`. Values are provider
-class names. These classes could be either created in the project itself or provided by a package.
+class names or provider instances. These classes could be either created in the project itself or provided by a package.
 
 If you need to configure some options for a service, similar to direct container configuration, take values
 from `$params` and pass them to providers.
 
-Provider should implement a single method, `public function register(Container $container): void`. In this method you
-need to add a service to container using `set()` method. Below is a provider for a cache service:
+Provider should implement `Yiisoft\Di\ServiceProviderInterface`. Below is a provider for a cache service:
 
 ```php
 use Psr\Container\ContainerInterface;
@@ -258,27 +252,31 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Cache\Cache;
 use Yiisoft\Cache\CacheInterface as YiiCacheInterface;
 use Yiisoft\Cache\File\FileCache;
-use Yiisoft\Di\Container;
-use Yiisoft\Di\Support\ServiceProvider;
+use Yiisoft\Di\ServiceProviderInterface;
 
-final readonly class CacheProvider extends ServiceProvider
+final readonly class CacheProvider implements ServiceProviderInterface
 {
     public function __construct(
         private string $cachePath = '@runtime/cache'
     )
     {
-        $this->cachePath = $cachePath;
     }
 
-    public function register(Container $container): void
+    public function getDefinitions(): array
     {
-        $container->set(CacheInterface::class, function (ContainerInterface $container) {
-            $aliases = $container->get(Aliases::class);
+        return [
+            CacheInterface::class => function (ContainerInterface $container) {
+                $aliases = $container->get(Aliases::class);
 
-            return new FileCache($aliases->get($this->cachePath));
-        });
+                return new FileCache($aliases->get($this->cachePath));
+            },
+            YiiCacheInterface::class => Cache::class,
+        ];
+    }
 
-        $container->set(YiiCacheInterface::class, Cache::class);
+    public function getExtensions(): array
+    {
+        return [];
     }
 }
 ```

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -39,6 +39,7 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 - [Domain](structure/domain.md)
 - [Service components](structure/service.md)
 - [Packages](structure/package.md)
+- [Designing packages](structure/designing-packages.md)
 
 ## Handling requests
 

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -41,7 +41,7 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 
 ## Packages
 
-- [Packages](structure/package.md)
+- [Using packages](structure/package.md)
 - [Designing packages](structure/designing-packages.md)
 
 ## Handling requests

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -38,6 +38,9 @@ We release this guide under the [Terms of Yii Documentation](https://www.yiifram
 - [Middleware](structure/middleware.md)
 - [Domain](structure/domain.md)
 - [Service components](structure/service.md)
+
+## Packages
+
 - [Packages](structure/package.md)
 - [Designing packages](structure/designing-packages.md)
 

--- a/src/guide/structure/designing-packages.md
+++ b/src/guide/structure/designing-packages.md
@@ -4,6 +4,37 @@ This page describes how to design a Composer package that adds behavior to a Yii
 Use it when your package needs to register services, routes, events, commands, assets, migrations, translations,
 or a theme.
 
+For installing and updating packages in an application, see [Using packages](package.md).
+
+## Composer metadata
+
+Each package must have a `composer.json` file in its root directory. At minimum, define a package name, dependencies,
+autoloading, and Yii config metadata when the package integrates with a Yii application.
+
+Use a package name in the `vendor-name/project-name` format:
+
+```json
+{
+    "name": "vendor/blog",
+    "type": "library",
+    "description": "Blog integration for Yii applications",
+    "require": {
+        "php": ">=8.2",
+        "yiisoft/router": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Blog\\": "src/"
+        }
+    }
+}
+```
+
+Use stable dependency constraints for stable releases. Avoid using `yiisoft` as your vendor name because it is reserved
+for Yii packages.
+
+If your package requires a Yii application, prefixing the project name with `yii-` can make that clear on Packagist.
+
 ## Package layout
 
 A Yii-aware package is a regular Composer package with PHP classes, optional resource files, and optional config files.
@@ -458,3 +489,11 @@ After changing config group mappings, they should rebuild the merge plan with:
 ```sh
 composer yii-config-rebuild
 ```
+
+## Releasing packages
+
+Before tagging a release, test the package by itself and inside a minimal Yii application. Include a `README.md`,
+`CHANGELOG.md`, and `UPGRADE.md` when behavior or configuration changes require explanation.
+
+Use [semantic versioning](https://semver.org) for public releases. After the first release, do not edit migrations that
+users may already have applied; add new migrations instead.

--- a/src/guide/structure/designing-packages.md
+++ b/src/guide/structure/designing-packages.md
@@ -1,0 +1,438 @@
+# Designing packages for Yii applications
+
+This page describes how to design a Composer package that adds behavior to a Yii application through configuration.
+Use it when your package needs to register services, routes, events, commands, assets, migrations, translations,
+or a theme.
+
+## Package layout
+
+A Yii-aware package is a regular Composer package with PHP classes, optional resource files, and optional config files.
+Keep the configuration in a predictable directory and make the public API explicit:
+
+```
+composer.json
+config/
+    params.php
+    di.php
+    routes.php
+    events.php
+    params-console.php
+    di-console.php
+src/
+    ...
+assets/
+    ...
+migrations/
+    ...
+messages/
+    ...
+views/
+    ...
+```
+
+Use only the files your package needs. For example, a package with console commands but no web routes does not need
+`routes.php`.
+
+## Config plugin metadata
+
+Yii applications use [yiisoft/config](https://github.com/yiisoft/config) to discover package configuration.
+Declare the config files in the `extra.config-plugin` section of `composer.json`:
+
+```json
+{
+    "name": "vendor/blog",
+    "type": "library",
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Blog\\": "src/"
+        }
+    },
+    "extra": {
+        "config-plugin-options": {
+            "source-directory": "config"
+        },
+        "config-plugin": {
+            "params": "params.php",
+            "di": "di.php",
+            "routes": "routes.php",
+            "events": "events.php",
+            "params-console": "params-console.php",
+            "di-console": "di-console.php"
+        }
+    }
+}
+```
+
+`source-directory` is relative to the package root. Each `config-plugin` key is a config group name and each value is
+a path relative to `source-directory`.
+
+Use the common, web, and console groups consistently:
+
+- `params`, `di`, `di-providers`, `di-delegates`, `events`, and `bootstrap` apply to both web and console entry points.
+- `params-web`, `di-web`, `di-providers-web`, `events-web`, `bootstrap-web`, and `routes` apply to web entry points.
+- `params-console`, `di-console`, `di-providers-console`, `events-console`, and `bootstrap-console` apply to console
+  entry points.
+
+If your package defines a new config group, document how an application should load that group. Prefer the standard
+groups when you integrate with Yii services because application templates and Yii packages already use these names.
+
+After users install, update, remove, or dump Composer autoload files, the config plugin rebuilds the merge plan that
+Yii reads at runtime. If users edit their root package configuration manually, ask them to run:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Parameters
+
+Put default options in `params.php`. Group package parameters under the Composer package name to avoid collisions:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'vendor/blog' => [
+        'postsPerPage' => 20,
+        'cacheTtl' => 3600,
+    ],
+];
+```
+
+Application developers can override these values in their own `config/common/params.php`,
+`config/web/params.php`, `config/console/params.php`, or environment-specific parameter files.
+
+Do not read environment variables or global state from package code when a parameter can express the choice. Use
+parameters to configure services through DI definitions or service providers.
+
+## DI definitions
+
+Use `di.php`, `di-web.php`, or `di-console.php` for direct container definitions:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Blog\PostRepository;
+use Vendor\Blog\PostRepositoryInterface;
+
+/** @var array $params */
+
+return [
+    PostRepositoryInterface::class => [
+        'class' => PostRepository::class,
+        '__construct()' => [
+            'cacheTtl' => $params['vendor/blog']['cacheTtl'],
+        ],
+    ],
+];
+```
+
+Prefer direct DI definitions when the configuration describes one service clearly.
+
+## DI service providers
+
+Use a DI provider when registration is code: several related services, optional classes, aliases, decorators,
+or environment checks.
+
+Register providers in a provider config group:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Blog\Provider\BlogProvider;
+
+return [
+    'vendor/blog/provider' => BlogProvider::class,
+];
+```
+
+Declare the group in `composer.json`:
+
+```json
+"extra": {
+    "config-plugin-options": {
+        "source-directory": "config"
+    },
+    "config-plugin": {
+        "di-providers": "di-providers.php"
+    }
+}
+```
+
+A provider can register several services:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\Blog\Provider;
+
+use Vendor\Blog\PostRepository;
+use Vendor\Blog\PostRepositoryInterface;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\Support\ServiceProvider;
+
+final class BlogProvider extends ServiceProvider
+{
+    public function register(Container $container): void
+    {
+        $container->set(PostRepositoryInterface::class, PostRepository::class);
+    }
+}
+```
+
+## Routes
+
+Web packages can add routes through the `routes` group:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Blog\Web\Post\IndexAction;
+use Yiisoft\Router\Group;
+use Yiisoft\Router\Route;
+
+return [
+    Group::create('/blog')->routes(
+        Route::get('')
+            ->action(IndexAction::class)
+            ->name('vendor/blog/index'),
+    ),
+];
+```
+
+Route names should be package-prefixed. This avoids collisions with application routes and with routes from other
+packages.
+
+Keep package routes small and overridable. If an application needs full control over URLs, document the actions and
+let the application define its own routes.
+
+## Events
+
+Use the `events`, `events-web`, or `events-console` group to attach package handlers to events:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Blog\Event\PostPublished;
+use Vendor\Blog\EventHandler\ClearPostListCache;
+
+return [
+    PostPublished::class => [
+        ClearPostListCache::class,
+    ],
+];
+```
+
+Handlers can be closures, callables, invokable objects, invokable class names, or DI aliases supported by the event
+dispatcher configuration. Prefer class names for package handlers because applications can override their dependencies
+through the container.
+
+## Assets
+
+If your package ships CSS, JavaScript, images, or fonts, define asset bundles as PHP classes:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\Blog\Asset;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class BlogAsset extends AssetBundle
+{
+    public ?string $sourcePath = __DIR__ . '/../../assets';
+
+    public array $css = [
+        'blog.css',
+    ];
+
+    public array $js = [
+        'blog.js',
+    ];
+}
+```
+
+Users can register the bundle from a view, widget, view injection, or action:
+
+```php
+$assetManager->register(BlogAsset::class);
+```
+
+Use `$sourcePath` for files shipped inside the package. Use `$basePath` and `$baseUrl` only when the files are already
+in a public web directory.
+
+## Migrations
+
+Packages that need database schema changes should ship migrations and add their namespace or path to
+`yiisoft/db-migration` parameters.
+
+For namespaced migrations:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'yiisoft/db-migration' => [
+        'sourceNamespaces' => [
+            'Vendor\\Blog\\Migration',
+        ],
+    ],
+];
+```
+
+For path-based migrations:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'yiisoft/db-migration' => [
+        'sourcePaths' => [
+            __DIR__ . '/../migrations',
+        ],
+    ],
+];
+```
+
+Put this in `params-console.php` and declare it as `params-console` in `composer.json`.
+
+Package migrations must be stable after release. Do not edit a migration that users may already have applied. Add a
+new migration instead.
+
+## Translations
+
+If the package has user-facing messages, give it a dedicated translation category and register a category source:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\IntlMessageFormatter;
+use Yiisoft\Translator\Message\Php\MessageSource;
+
+return [
+    'translation.vendor-blog' => [
+        'definition' => static function (): CategorySource {
+            $messageSource = new MessageSource(__DIR__ . '/../messages');
+
+            return new CategorySource(
+                'vendor-blog',
+                $messageSource,
+                new IntlMessageFormatter(),
+                $messageSource,
+            );
+        },
+        'tags' => ['translation.categorySource'],
+    ],
+];
+```
+
+Store messages by locale and category:
+
+```
+messages/
+    en-US/
+        vendor-blog.php
+    de/
+        vendor-blog.php
+```
+
+Use the explicit category when translating:
+
+```php
+$translator->translate('post.created', category: 'vendor-blog');
+```
+
+## Themes
+
+A package can ship view files and assets for a theme. Yii view configuration keeps theme settings under
+`yiisoft/view.theme`, so a theme package can provide default parameters:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'yiisoft/view' => [
+        'theme' => [
+            'pathMap' => [
+                '@views' => __DIR__ . '/../views',
+            ],
+            'basePath' => __DIR__ . '/../assets',
+            'baseUrl' => '@assetsUrl/vendor-blog',
+        ],
+    ],
+];
+```
+
+Themes replace view paths according to a path map. Document which application view paths your theme replaces and which
+asset URL must be published or exposed by the application.
+
+If your package only provides optional theme files, do not make the theme active by default. Provide the view files,
+asset bundle, and a documented parameter snippet so the application can opt in.
+
+## Console commands
+
+Console packages can add Symfony Console commands through `params-console`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Vendor\Blog\Command\ReindexCommand;
+
+return [
+    'yiisoft/yii-console' => [
+        'commands' => [
+            'blog/reindex' => ReindexCommand::class,
+        ],
+    ],
+];
+```
+
+Command names should be package-prefixed. Keep command dependencies constructor-injected and registered through DI.
+
+## Application overrides
+
+Package configuration is the default layer. The application can override it in its root package configuration.
+Design for that:
+
+- Use package-prefixed parameter keys, route names, event handler IDs, and DI aliases.
+- Keep default configuration small and documented.
+- Avoid doing irreversible work during service registration.
+- Put optional integrations in separate config files or providers when they require optional Composer packages.
+- Test the package inside a minimal Yii application so the config plugin, DI container, routes, console commands,
+  migrations, translations, and assets are exercised together.
+
+When a user needs to customize a package config file, they can copy it into the application with:
+
+```sh
+composer yii-config-copy
+```
+
+After changing config group mappings, they should rebuild the merge plan with:
+
+```sh
+composer yii-config-rebuild
+```

--- a/src/guide/structure/designing-packages.md
+++ b/src/guide/structure/designing-packages.md
@@ -12,7 +12,6 @@ Keep the configuration in a predictable directory and make the public API explic
 ```
 composer.json
 config/
-    configuration.php
     params.php
     di.php
     di-providers.php
@@ -39,8 +38,7 @@ Use only the files your package needs. For example, a package with console comma
 ## Config plugin metadata
 
 Yii applications use [yiisoft/config](https://github.com/yiisoft/config) to discover package configuration.
-Declare the config file in the `extra.config-plugin-file` section of `composer.json`, the same way the
-Yii application template does:
+Declare package config files in the `extra.config-plugin` section of `composer.json`:
 
 ```json
 {
@@ -52,37 +50,21 @@ Yii application template does:
         }
     },
     "extra": {
-        "config-plugin-file": "config/configuration.php"
+        "config-plugin": {
+            "params": "config/params.php",
+            "di": "config/di.php",
+            "di-providers": "config/di-providers.php",
+            "routes": "config/routes.php",
+            "events": "config/events.php",
+            "params-web": "config/params-web.php",
+            "params-console": "config/params-console.php",
+            "di-console": "config/di-console.php"
+        }
     }
 }
 ```
 
-In `config/configuration.php`, map Yii config groups to package config files:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-return [
-    'config-plugin-options' => [
-        'source-directory' => 'config',
-    ],
-    'config-plugin' => [
-        'params' => 'params.php',
-        'di' => 'di.php',
-        'di-providers' => 'di-providers.php',
-        'routes' => 'routes.php',
-        'events' => 'events.php',
-        'params-web' => 'params-web.php',
-        'params-console' => 'params-console.php',
-        'di-console' => 'di-console.php',
-    ],
-];
-```
-
-`config-plugin-file` is relative to the package root. The `source-directory` option is also relative to the package
-root. Each `config-plugin` key is a config group name and each value is a path relative to `source-directory`.
+Each `config-plugin` key is a config group name and each value is a path relative to the package root.
 
 Use the common, web, and console groups consistently:
 
@@ -166,16 +148,18 @@ declare(strict_types=1);
 use Vendor\Blog\Provider\BlogProvider;
 
 return [
-    'vendor/blog/provider' => BlogProvider::class,
+    'vendor/blog/post-repository' => BlogProvider::class,
 ];
 ```
 
-Declare the group in `config/configuration.php`:
+Declare the group in `composer.json`:
 
-```php
-'config-plugin' => [
-    'di-providers' => 'di-providers.php',
-],
+```json
+"extra": {
+    "config-plugin": {
+        "di-providers": "config/di-providers.php"
+    }
+}
 ```
 
 A provider can return several service definitions and extensions. Place the provider class in
@@ -344,7 +328,7 @@ return [
 ];
 ```
 
-Put this in `config/params-console.php` and declare it as `params-console` in `config/configuration.php`.
+Put this in `config/params-console.php` and declare it as `params-console` in `composer.json`.
 
 This only contributes package migration locations. The application still needs `yiisoft/db-migration` installed and
 a database connection configured before migration commands can run.

--- a/src/guide/structure/designing-packages.md
+++ b/src/guide/structure/designing-packages.md
@@ -450,11 +450,8 @@ Design for that:
 - Test the package inside a minimal Yii application so the config plugin, DI container, routes, console commands,
   migrations, translations, and assets are exercised together.
 
-When a user needs to customize a package config file, they can copy it into the application with:
-
-```sh
-composer yii-config-copy
-```
+When a user needs to customize package configuration, they usually do not need to copy the package config file. They can
+partially redefine the needed keys in the application configuration.
 
 After changing config group mappings, they should rebuild the merge plan with:
 

--- a/src/guide/structure/designing-packages.md
+++ b/src/guide/structure/designing-packages.md
@@ -12,10 +12,13 @@ Keep the configuration in a predictable directory and make the public API explic
 ```
 composer.json
 config/
+    configuration.php
     params.php
     di.php
+    di-providers.php
     routes.php
     events.php
+    params-web.php
     params-console.php
     di-console.php
 src/
@@ -36,7 +39,8 @@ Use only the files your package needs. For example, a package with console comma
 ## Config plugin metadata
 
 Yii applications use [yiisoft/config](https://github.com/yiisoft/config) to discover package configuration.
-Declare the config files in the `extra.config-plugin` section of `composer.json`:
+Declare the config file in the `extra.config-plugin-file` section of `composer.json`, the same way the
+Yii application template does:
 
 ```json
 {
@@ -48,23 +52,37 @@ Declare the config files in the `extra.config-plugin` section of `composer.json`
         }
     },
     "extra": {
-        "config-plugin-options": {
-            "source-directory": "config"
-        },
-        "config-plugin": {
-            "params": "params.php",
-            "di": "di.php",
-            "routes": "routes.php",
-            "events": "events.php",
-            "params-console": "params-console.php",
-            "di-console": "di-console.php"
-        }
+        "config-plugin-file": "config/configuration.php"
     }
 }
 ```
 
-`source-directory` is relative to the package root. Each `config-plugin` key is a config group name and each value is
-a path relative to `source-directory`.
+In `config/configuration.php`, map Yii config groups to package config files:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'config-plugin-options' => [
+        'source-directory' => 'config',
+    ],
+    'config-plugin' => [
+        'params' => 'params.php',
+        'di' => 'di.php',
+        'di-providers' => 'di-providers.php',
+        'routes' => 'routes.php',
+        'events' => 'events.php',
+        'params-web' => 'params-web.php',
+        'params-console' => 'params-console.php',
+        'di-console' => 'di-console.php',
+    ],
+];
+```
+
+`config-plugin-file` is relative to the package root. The `source-directory` option is also relative to the package
+root. Each `config-plugin` key is a config group name and each value is a path relative to `source-directory`.
 
 Use the common, web, and console groups consistently:
 
@@ -85,7 +103,8 @@ composer yii-config-rebuild
 
 ## Parameters
 
-Put default options in `params.php`. Group package parameters under the Composer package name to avoid collisions:
+Put default options in `config/params.php`. Group package parameters under the Composer package name to avoid
+collisions:
 
 ```php
 <?php
@@ -108,7 +127,7 @@ parameters to configure services through DI definitions or service providers.
 
 ## DI definitions
 
-Use `di.php`, `di-web.php`, or `di-console.php` for direct container definitions:
+Use `config/di.php`, `config/di-web.php`, or `config/di-console.php` for direct container definitions:
 
 ```php
 <?php
@@ -134,10 +153,10 @@ Prefer direct DI definitions when the configuration describes one service clearl
 
 ## DI service providers
 
-Use a DI provider when registration is code: several related services, optional classes, aliases, decorators,
-or environment checks.
+Use a DI provider when registration belongs together as a reusable unit: several related services, aliases,
+factory definitions, or extensions.
 
-Register providers in a provider config group:
+Register providers in `config/di-providers.php`:
 
 ```php
 <?php
@@ -151,20 +170,16 @@ return [
 ];
 ```
 
-Declare the group in `composer.json`:
+Declare the group in `config/configuration.php`:
 
-```json
-"extra": {
-    "config-plugin-options": {
-        "source-directory": "config"
-    },
-    "config-plugin": {
-        "di-providers": "di-providers.php"
-    }
-}
+```php
+'config-plugin' => [
+    'di-providers' => 'di-providers.php',
+],
 ```
 
-A provider can register several services:
+A provider can return several service definitions and extensions. Place the provider class in
+`src/Provider/BlogProvider.php`:
 
 ```php
 <?php
@@ -173,23 +188,38 @@ declare(strict_types=1);
 
 namespace Vendor\Blog\Provider;
 
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Vendor\Blog\CachedPostRepository;
 use Vendor\Blog\PostRepository;
 use Vendor\Blog\PostRepositoryInterface;
-use Yiisoft\Di\Container;
-use Yiisoft\Di\Support\ServiceProvider;
+use Yiisoft\Di\ServiceProviderInterface;
 
-final class BlogProvider extends ServiceProvider
+final class BlogProvider implements ServiceProviderInterface
 {
-    public function register(Container $container): void
+    public function getDefinitions(): array
     {
-        $container->set(PostRepositoryInterface::class, PostRepository::class);
+        return [
+            PostRepository::class => PostRepository::class,
+            PostRepositoryInterface::class => static fn (
+                ContainerInterface $container
+            ): CachedPostRepository => new CachedPostRepository(
+                $container->get(PostRepository::class),
+                $container->get(LoggerInterface::class),
+            ),
+        ];
+    }
+
+    public function getExtensions(): array
+    {
+        return [];
     }
 }
 ```
 
 ## Routes
 
-Web packages can add routes through the `routes` group:
+Web packages can add routes through `config/routes.php`, declared as the `routes` group:
 
 ```php
 <?php
@@ -217,7 +247,7 @@ let the application define its own routes.
 
 ## Events
 
-Use the `events`, `events-web`, or `events-console` group to attach package handlers to events:
+Use `config/events.php`, `config/events-web.php`, or `config/events-console.php` to attach package handlers to events:
 
 ```php
 <?php
@@ -240,7 +270,8 @@ through the container.
 
 ## Assets
 
-If your package ships CSS, JavaScript, images, or fonts, define asset bundles as PHP classes:
+If your package ships CSS, JavaScript, images, or fonts, define asset bundles as PHP classes. For example,
+place this class in `src/Asset/BlogAsset.php`:
 
 ```php
 <?php
@@ -253,6 +284,8 @@ use Yiisoft\Assets\AssetBundle;
 
 final class BlogAsset extends AssetBundle
 {
+    public ?string $basePath = '@assets';
+    public ?string $baseUrl = '@assetsUrl';
     public ?string $sourcePath = __DIR__ . '/../../assets';
 
     public array $css = [
@@ -271,8 +304,8 @@ Users can register the bundle from a view, widget, view injection, or action:
 $assetManager->register(BlogAsset::class);
 ```
 
-Use `$sourcePath` for files shipped inside the package. Use `$basePath` and `$baseUrl` only when the files are already
-in a public web directory.
+Use `$sourcePath` for files shipped inside the package. Use `$basePath` and `$baseUrl` as the public target where the
+asset manager publishes them.
 
 ## Migrations
 
@@ -311,14 +344,18 @@ return [
 ];
 ```
 
-Put this in `params-console.php` and declare it as `params-console` in `composer.json`.
+Put this in `config/params-console.php` and declare it as `params-console` in `config/configuration.php`.
+
+This only contributes package migration locations. The application still needs `yiisoft/db-migration` installed and
+a database connection configured before migration commands can run.
 
 Package migrations must be stable after release. Do not edit a migration that users may already have applied. Add a
 new migration instead.
 
 ## Translations
 
-If the package has user-facing messages, give it a dedicated translation category and register a category source:
+If the package has user-facing messages, give it a dedicated translation category and register a category source in
+`config/di.php`:
 
 ```php
 <?php
@@ -364,8 +401,9 @@ $translator->translate('post.created', category: 'vendor-blog');
 
 ## Themes
 
-A package can ship view files and assets for a theme. Yii view configuration keeps theme settings under
-`yiisoft/view.theme`, so a theme package can provide default parameters:
+A package can ship view files and assets for a theme. Do not activate it from vendor package configuration. Instead,
+document the root application configuration needed to enable it. For the application template, this belongs in
+`config/web/params.php`:
 
 ```php
 <?php
@@ -376,9 +414,9 @@ return [
     'yiisoft/view' => [
         'theme' => [
             'pathMap' => [
-                '@views' => __DIR__ . '/../views',
+                '@views' => '@vendor/vendor/blog/views',
             ],
-            'basePath' => __DIR__ . '/../assets',
+            'basePath' => '@vendor/vendor/blog/assets',
             'baseUrl' => '@assetsUrl/vendor-blog',
         ],
     ],
@@ -388,12 +426,15 @@ return [
 Themes replace view paths according to a path map. Document which application view paths your theme replaces and which
 asset URL must be published or exposed by the application.
 
+Do not set `yiisoft/view.theme` directly in vendor package configuration. `yiisoft/view` already defines that key, and
+duplicate keys in the same configuration layer are not allowed.
+
 If your package only provides optional theme files, do not make the theme active by default. Provide the view files,
 asset bundle, and a documented parameter snippet so the application can opt in.
 
 ## Console commands
 
-Console packages can add Symfony Console commands through `params-console`:
+Console packages can add Symfony Console commands through `config/params-console.php`:
 
 ```php
 <?php

--- a/src/guide/structure/package.md
+++ b/src/guide/structure/package.md
@@ -1,213 +1,108 @@
-# Packages
+# Using packages
 
-Reusable code could be released as [a Composer package](https://getcomposer.org/doc/05-repositories.md#package).
-It could be an infrastructure library, a module representing one of the application contexts or, basically, any
-reusable code.
+Reusable code is distributed as [Composer packages](https://getcomposer.org/doc/05-repositories.md#package).
+A package can be an infrastructure library, a Yii integration, a reusable feature, or a module representing an
+application context.
 
-## Using packages <span id="using-packages"></span>
-
-By default, Composer installs packages registered on [Packagist](https://packagist.org/) — the biggest repository
-for open source PHP packages. You can look for packages on Packagist. You may also
-[create your own repository](https://getcomposer.org/doc/05-repositories.md#repository) and configure Composer
-to use it. This is useful if you're developing private packages that you want to share within your projects only.
-
-Packages installed by Composer are stored in the `vendor` directory of your project. 
-Because the Composer is a dependency manager, when it installs a package, it will also install all its dependent packages.
-
-> [!WARNING]
-> `vendor` directory of your application should never be modified.
-
-A package could be installed with the following command:
-
-```
-composer install vendor-name/package-name
-```
-
-After it's done, Composer modifies `composer.json` and `composer.lock`. The former defines what packages to install,
-and their version constraints the latter stores a snapshot of exact versions actually installed.
-
-Classes from the package will be available immediately via [autoloading](../concept/autoloading.md).
-
-## Creating packages <span id="creating-packages"></span>
-
-
-You may consider creating a package when you feel the need to share with other people your great code.
-A package can contain any code you like, such as a helper class, a widget, a service, middleware, the whole module, etc.
-
-Below are the basic steps you may follow.
-
-1. Create a project for your package and host it on a VCS repository, such as [GitHub.com](https://github.com).
-   The development and maintenance work for the package should be done on this repository.
-2. Under the root directory of the project, create a file named `composer.json` as required by Composer. Please
-   refer to the next subsection for more details.
-3. Register your package with a Composer repository, such as [Packagist](https://packagist.org/), so that
-   other users can find and install your package using Composer.
-
-
-### `composer.json` <span id="composer-json"></span>
-
-Each Composer package must have a `composer.json` file in its root directory. The file contains the metadata about
-the package. You may find the complete specification about this file in the [Composer Manual](https://getcomposer.org/doc/01-basic-usage.md#composer-json-project-setup).
-The following example shows the `composer.json` file for the `yiisoft/yii-widgets` package:
-
-```json
-{
-    "name": "yiisoft/yii-widgets",
-    "type": "library",
-    "description": "Yii widgets collection",
-    "keywords": [
-        "yii",
-        "widgets"
-    ],
-    "homepage": "https://www.yiiframework.com/",
-    "license": "BSD-3-Clause",
-    "support": {
-        "issues": "https://github.com/yiisoft/yii-widgets/issues?state=open",
-        "forum": "https://www.yiiframework.com/forum/",
-        "wiki": "https://www.yiiframework.com/wiki/",
-        "irc": "ircs://irc.libera.chat:6697/yii",
-        "chat": "https://t.me/yii3en",
-        "source": "https://github.com/yiisoft/yii-widgets"
-    },
-    "funding": [
-        {
-            "type": "opencollective",
-            "url": "https://opencollective.com/yiisoft"
-        },
-        {
-            "type": "github",
-            "url": "https://github.com/sponsors/yiisoft"
-        }
-    ],
-    "require": {
-        "php": "^7.4|^8.0",
-        "yiisoft/aliases": "^1.1|^2.0",
-        "yiisoft/cache": "^1.0",
-        "yiisoft/html": "^2.0",
-        "yiisoft/view": "^4.0",
-        "yiisoft/widget": "^1.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.16",
-        "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.18",
-        "yiisoft/psr-dummy-provider": "^1.0",
-        "yiisoft/test-support": "^1.3"
-    },
-    "autoload": {
-        "psr-4": {
-            "Yiisoft\\Yii\\Widgets\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Yiisoft\\Yii\\Widgets\\Tests\\": "tests"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.0.x-dev"
-        }
-    },
-    "scripts": {
-        "test": "phpunit --testdox --no-interaction",
-        "test-watch": "phpunit-watcher watch"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "infection/extension-installer": true,
-            "composer/package-versions-deprecated": true
-        }
-    }
-}
-```
-
-
-#### Package Name <span id="package-name"></span>
-
-Each Composer package should have a package name which uniquely identifies the package among all others.
-The format of package names is `vendorName/projectName`. For example, in the package name `yiisoft/queue`,
-the vendor name, and the project name are `yiisoft` and `queue`, respectively.
-
-> [!WARNING]
-> Don't use `yiisoft` as your vendor name as it's reserved for use by the Yii itself.
-
-We recommend you prefix `yii-` to the project name for packages that aren't able to work as general PHP
-packages and require Yii application. This will allow users to more easily tell whether a package is Yii specific.
-
-
-#### Dependencies <span id="dependencies"></span>
-
-If your extension depends on other packages, you should list them in `require` section of `composer.json`.
-Make sure you also list appropriate version constraints (e.g. `^1.0`, `@stable`) for each dependent package.
-Use stable dependencies when your extension is released in a stable version.
-
-#### Class Autoloading <span id="class-autoloading"></span>
-
-In order for your classes to be autoloaded, you should specify the `autoload` entry in the `composer.json` file,
-like shown below:
-
-```json
-{
-    // ....
-
-    "autoload": {
-        "psr-4": {
-            "MyVendorName\\MyPackageName\\": "src"
-        }
-    }
-}
-```
-
-You may list one or multiple root namespaces and their corresponding file paths.
-
-If your package integrates with Yii application configuration, see
+This page explains how to use packages in an application. To create a Yii-aware package, see
 [Designing packages for Yii applications](designing-packages.md).
 
-### Recommended Practices <span id="recommended-practices"></span>
+## Installing packages <span id="installing-packages"></span>
 
-Because packages are meant to be used by other people, you often need to make an extra effort during development.
-Below, we introduce some common and recommended practices in creating high-quality extensions.
+By default, Composer installs packages registered on [Packagist](https://packagist.org/), the main repository for
+open source PHP packages.
 
+Install a package with:
 
-#### Testing <span id="testing"></span>
+```sh
+composer require vendor-name/package-name
+```
 
-You want your package to run flawlessly without bringing problems to other people. To reach this goal, you should
-test your extension before releasing it to the public.
+Composer updates two files:
 
-It's recommended that you create various test cases to cover your extension code rather than relying on manual tests.
-Each time before you release a new version of your package, you may run these test cases to make sure
-everything is in good shape. For more details, please refer to the [Testing](../testing/overview.md) section.
+- `composer.json` stores the package name and version constraint.
+- `composer.lock` stores the exact versions installed.
 
+Commit both files so other environments install the same dependency versions.
 
-#### Versioning <span id="versioning"></span>
+Installed packages are stored in the application `vendor/` directory.
 
-You should give each release of your extension a version number (e.g. `1.0.1`). We recommend you follow the
-[semantic versioning](https://semver.org) practice when determining what version numbers should be used.
+> [!WARNING]
+> Never edit files in `vendor/` directly. Change application configuration, extend classes, decorate services, or
+> contribute fixes to the package instead.
 
+Package classes are available through Composer autoloading after installation. See [Autoloading](../concept/autoloading.md)
+for details.
 
-#### Releasing <span id="releasing"></span>
+## Updating packages <span id="updating-packages"></span>
 
-To let other people know about your package, you need to release it to the public.
+Update a package within the version constraint recorded in `composer.json`:
 
-If it's the first time you're releasing a package, you should register it in a Composer repository, such as
-[Packagist](https://packagist.org/).
-After that, all you need to do is create a release tag (for example, `v1.0.1`)
-on the VCS repository of your extension and notify the Composer repository about the new release. People will
-then be able to find the new release and install or update the package through the Composer repository.
+```sh
+composer update vendor-name/package-name
+```
 
-In the release of your package, in addition to code files, you should also consider including the following to
-help other people learn about and use your extension:
+Change the accepted version constraint with `composer require`:
 
-* A readme file in the package root directory: it describes what your extension does and how to install and use it.
-  We recommend you write it in [Markdown](https://daringfireball.net/projects/markdown/) format and name the file
-  as `README.md`.
-* A changelog file in the package root directory: it lists what changes are made in each release. The file
-  may be written in Markdown format and named as `CHANGELOG.md`.
-* An upgrade file in the package root directory: it gives the instructions on how to upgrade from older releases
-  of the extension. The file may be written in Markdown format and named as `UPGRADE.md`.
-* Tutorials, demos, screenshots, etc.: these are needed if your extension provides many features that can't be
-  fully covered in the readme file.
-* API documentation: your code should be well-documented to allow other people to more easily read and understand it.
+```sh
+composer require vendor-name/package-name:^2.0
+```
+
+After updating a Yii-aware package, Composer rebuilds Yii's configuration merge plan. If you changed configuration
+group mappings manually, rebuild it explicitly:
+
+```sh
+composer yii-config-rebuild
+```
+
+## Removing packages <span id="removing-packages"></span>
+
+Remove a package with:
+
+```sh
+composer remove vendor-name/package-name
+```
+
+Then remove application code and configuration that referenced classes, services, routes, commands, assets, migrations,
+or translations from that package.
+
+## Private packages <span id="private-packages"></span>
+
+For private code, configure Composer repositories in the application `composer.json`. Common options are:
+
+- `vcs` for a Git repository.
+- `path` for a local package during development.
+- `composer` for a private Composer repository.
+
+For example, to work with a package located next to the application:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../packages/blog"
+        }
+    ]
+}
+```
+
+Then install it normally:
+
+```sh
+composer require vendor/blog
+```
+
+Read more in the [Composer repository documentation](https://getcomposer.org/doc/05-repositories.md).
+
+## Package configuration <span id="package-configuration"></span>
+
+Some Yii packages provide default configuration through [yiisoft/config](https://github.com/yiisoft/config).
+After installation, the package configuration becomes part of the vendor layer and the application can override it in
+the root package configuration.
+
+Prefer partial overrides in application config files over copying whole package config files. For example, override
+only the parameter or service definition you need.
+
+For more details, see [Configuration](../concept/configuration.md) and
+[Designing packages for Yii applications](designing-packages.md).

--- a/src/guide/structure/package.md
+++ b/src/guide/structure/package.md
@@ -163,6 +163,9 @@ like shown below:
 
 You may list one or multiple root namespaces and their corresponding file paths.
 
+If your package integrates with Yii application configuration, see
+[Designing packages for Yii applications](designing-packages.md).
+
 ### Recommended Practices <span id="recommended-practices"></span>
 
 Because packages are meant to be used by other people, you often need to make an extra effort during development.


### PR DESCRIPTION
Closes #360.

## Summary
- add a guide for designing Yii-aware Composer packages that provide application configuration
- cover config groups, routes, DI providers, params, assets, events, migrations, translations, themes, and console commands
- add the page to the guide TOC and VitePress sidebar

## Checks
- npm run build
- npm run check-links -- src/guide/structure/designing-packages.md src/guide/structure/package.md src/guide/index.md