### PR TITLE
Fix #268: Add rolling update migrations recipe

### DIFF
--- a/_translations/po/es/cookbook_deployment_rolling-update-migrations.md.po
+++ b/_translations/po/es/cookbook_deployment_rolling-update-migrations.md.po
@@ -1,0 +1,496 @@
+# Spanish translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: 2026-05-30 09:18+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Rolling updates keep old and new application instances running at the same time. This makes database changes more delicate than in a single-server deployment: both application versions must work with the same database while the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Remove obsolete database structures only after every old application instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move the application code. Finally contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "During a rolling update, requests may be served by different versions of the application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Development tools -"
+msgid "Deployment flow"
+msgstr "Herramientas de Desarrollo"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply this migration to production while the current application version is still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For Yii applications, run migrations with the same command you use in regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "./yii migrate\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application instance run migrations on startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add it as nullable."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Generating API documentation"
+msgid "Renaming a column"
+msgstr "Generación de Documentación de API"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns and reads the new column with a fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior on the exact database engine and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that old application instances, workers, and scheduled commands are stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Introduction +"
+msgid "Drop it in a separate migration."
+msgstr "Introducción"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Indexes and constraints may be logically compatible but operationally risky because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For indexes:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For constraints:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Introduction +"
+msgid "Data migrations"
+msgstr "Introducción"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Data migrations that touch many rows should be safe to run while the application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "avoid depending on current application service or entity logic because that logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For very large backfills, use a console command or background job after the schema migration. The schema migration should prepare the database; the background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+msgid "Reverting"
+msgstr "Pruebas (Testing)"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "after cleanup, deploy a new forward migration that restores the required structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "restore from backup only when data was actually lost and no forward repair is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Checklist"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "long-running schema operations will not block production traffic unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/po/es/cookbook_index.md.po
+++ b/_translations/po/es/cookbook_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -100,4 +100,9 @@ msgstr ""
 #. type: Bullet: '- '
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid "[Applying migrations during rolling updates](deployment/rolling-update-migrations.md)"
 msgstr ""

--- a/_translations/po/id/cookbook_deployment_rolling-update-migrations.md.po
+++ b/_translations/po/id/cookbook_deployment_rolling-update-migrations.md.po
@@ -1,0 +1,495 @@
+# Indonesian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: 2026-05-30 09:18+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Rolling updates keep old and new application instances running at the same time. This makes database changes more delicate than in a single-server deployment: both application versions must work with the same database while the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Remove obsolete database structures only after every old application instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move the application code. Finally contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "During a rolling update, requests may be served by different versions of the application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Development tools -"
+msgid "Deployment flow"
+msgstr "Alat Pengembangan -"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply this migration to production while the current application version is still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For Yii applications, run migrations with the same command you use in regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "./yii migrate\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application instance run migrations on startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add it as nullable."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Generating API documentation"
+msgid "Renaming a column"
+msgstr "Membuat Dokumentasi API"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns and reads the new column with a fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior on the exact database engine and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that old application instances, workers, and scheduled commands are stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Container configuration"
+msgid "Drop it in a separate migration."
+msgstr "Konfigurasi container"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Indexes and constraints may be logically compatible but operationally risky because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For indexes:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For constraints:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Configuration"
+msgid "Data migrations"
+msgstr "Konfigurasi"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Data migrations that touch many rows should be safe to run while the application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "avoid depending on current application service or entity logic because that logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For very large backfills, use a console command or background job after the schema migration. The schema migration should prepare the database; the background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+msgid "Reverting"
+msgstr "Pengujian -"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "after cleanup, deploy a new forward migration that restores the required structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "restore from backup only when data was actually lost and no forward repair is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Checklist"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "long-running schema operations will not block production traffic unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/po/id/cookbook_index.md.po
+++ b/_translations/po/id/cookbook_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,4 +103,9 @@ msgstr ""
 #. type: Bullet: '- '
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid "[Applying migrations during rolling updates](deployment/rolling-update-migrations.md)"
 msgstr ""

--- a/_translations/po/it/cookbook_deployment_rolling-update-migrations.md.po
+++ b/_translations/po/it/cookbook_deployment_rolling-update-migrations.md.po
@@ -1,0 +1,498 @@
+# Italian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: 2026-05-30 09:18+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Rolling updates keep old and new application instances running at the same time. This makes database changes more delicate than in a single-server deployment: both application versions must work with the same database while the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Remove obsolete database structures only after every old application instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move the application code. Finally contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "During a rolling update, requests may be served by different versions of the application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Development tools"
+msgid "Deployment flow"
+msgstr "Strumenti di sviluppo"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply this migration to production while the current application version is still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For Yii applications, run migrations with the same command you use in regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "APP_ENV=dev ./yii serve --port=80\n"
+msgid "./yii migrate\n"
+msgstr "APP_ENV=dev ./yii serve --port=80\n"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application instance run migrations on startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add it as nullable."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Creating a project"
+msgid "Renaming a column"
+msgstr "Creazione di un progetto"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns and reads the new column with a fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior on the exact database engine and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that old application instances, workers, and scheduled commands are stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Application structure"
+msgid "Drop it in a separate migration."
+msgstr "Struttura applicativa"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Indexes and constraints may be logically compatible but operationally risky because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For indexes:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For constraints:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Introduction"
+msgid "Data migrations"
+msgstr "Introduzione"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Data migrations that touch many rows should be safe to run while the application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "avoid depending on current application service or entity logic because that logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For very large backfills, use a console command or background job after the schema migration. The schema migration should prepare the database; the background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Testing"
+msgid "Reverting"
+msgstr "Testing"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "after cleanup, deploy a new forward migration that restores the required structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "restore from backup only when data was actually lost and no forward repair is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Checklist"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "long-running schema operations will not block production traffic unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/po/it/cookbook_index.md.po
+++ b/_translations/po/it/cookbook_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -108,4 +108,9 @@ msgstr ""
 #. type: Bullet: '- '
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid "[Applying migrations during rolling updates](deployment/rolling-update-migrations.md)"
 msgstr ""

--- a/_translations/po/ru/cookbook_deployment_rolling-update-migrations.md.po
+++ b/_translations/po/ru/cookbook_deployment_rolling-update-migrations.md.po
@@ -1,0 +1,496 @@
+# Russian translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: 2026-05-30 09:18+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Rolling updates keep old and new application instances running at the same time. This makes database changes more delicate than in a single-server deployment: both application versions must work with the same database while the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Remove obsolete database structures only after every old application instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move the application code. Finally contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "During a rolling update, requests may be served by different versions of the application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Deployment flow"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply this migration to production while the current application version is still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For Yii applications, run migrations with the same command you use in regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "./yii migrate\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application instance run migrations on startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add it as nullable."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Creating a project"
+msgid "Renaming a column"
+msgstr "Создание проекта"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns and reads the new column with a fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior on the exact database engine and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that old application instances, workers, and scheduled commands are stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Sentry integration"
+msgid "Drop it in a separate migration."
+msgstr "Интеграция с Sentry"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Indexes and constraints may be logically compatible but operationally risky because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For indexes:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For constraints:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Configuration"
+msgid "Data migrations"
+msgstr "Настройка"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Data migrations that touch many rows should be safe to run while the application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "avoid depending on current application service or entity logic because that logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For very large backfills, use a console command or background job after the schema migration. The schema migration should prepare the database; the background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Routing"
+msgid "Reverting"
+msgstr "Маршрутизация"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "after cleanup, deploy a new forward migration that restores the required structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "restore from backup only when data was actually lost and no forward repair is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Checklist"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "long-running schema operations will not block production traffic unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/po/ru/cookbook_index.md.po
+++ b/_translations/po/ru/cookbook_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: 2025-12-24 08:23+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,4 +103,9 @@ msgstr ""
 #. type: Bullet: '- '
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid "[Applying migrations during rolling updates](deployment/rolling-update-migrations.md)"
 msgstr ""

--- a/_translations/po/zh-CN/cookbook_deployment_rolling-update-migrations.md.po
+++ b/_translations/po/zh-CN/cookbook_deployment_rolling-update-migrations.md.po
@@ -1,0 +1,504 @@
+# Language zh-CN translations for PACKAGE package
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: 2026-05-30 09:18+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh-CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Rolling updates keep old and new application instances running at the same time. This makes database changes more delicate than in a single-server deployment: both application versions must work with the same database while the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Remove obsolete database structures only after every old application instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move the application code. Finally contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "During a rolling update, requests may be served by different versions of the application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Development tools"
+msgid "Deployment flow"
+msgstr "开发工具"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Apply this migration to production while the current application version is still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For Yii applications, run migrations with the same command you use in regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "./yii migrate\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application instance run migrations on startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "addColumn - adding a column."
+msgid "Adding a column"
+msgstr "addColumn — 添加一列。"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "A callable."
+msgid "Add it as nullable."
+msgstr "可调用对象。"
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Creating a migration"
+msgid "Renaming a column"
+msgstr "创建迁移"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns and reads the new column with a fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior on the exact database engine and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that old application instances, workers, and scheduled commands are stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "create - empty migration."
+msgid "Drop it in a separate migration."
+msgstr "create — 空迁移。"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Indexes and constraints may be logically compatible but operationally risky because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Some examples:"
+msgid "For indexes:"
+msgstr "一些示例："
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy
+#| msgid "Constants"
+msgid "For constraints:"
+msgstr "常量"
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "apply migrations;"
+msgid "Data migrations"
+msgstr "应用迁移；"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Data migrations that touch many rows should be safe to run while the application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "avoid depending on current application service or entity logic because that logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For very large backfills, use a console command or background job after the schema migration. The schema migration should prepare the database; the background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Redirecting"
+msgid "Reverting"
+msgstr "重定向"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "after cleanup, deploy a new forward migration that restores the required structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "restore from backup only when data was actually lost and no forward repair is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, fuzzy, no-wrap
+#| msgid "Checkout"
+msgid "Checklist"
+msgstr "结账"
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "long-running schema operations will not block production traffic unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/po/zh-CN/cookbook_index.md.po
+++ b/_translations/po/zh-CN/cookbook_index.md.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: 2026-01-08 08:54+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,3 +102,8 @@ msgstr "[使用垂直切片按用例组织代码](organizing-code/structuring-by
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
 msgstr "[部署到 Docker Swarm](deployment/docker-swarm.md)"
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid "[Applying migrations during rolling updates](deployment/rolling-update-migrations.md)"
+msgstr ""

--- a/_translations/po4a.conf
+++ b/_translations/po4a.conf
@@ -15,6 +15,7 @@
 [type: markdown] ../src/cookbook/deployment/docker-swarm-caddy.md $lang:../src/$lang/cookbook/deployment/docker-swarm-caddy.md pot=cookbook_deployment_docker-swarm-caddy.md
 [type: markdown] ../src/cookbook/deployment/docker-swarm-traefik.md $lang:../src/$lang/cookbook/deployment/docker-swarm-traefik.md pot=cookbook_deployment_docker-swarm-traefik.md
 [type: markdown] ../src/cookbook/deployment/docker-swarm.md $lang:../src/$lang/cookbook/deployment/docker-swarm.md pot=cookbook_deployment_docker-swarm.md
+[type: markdown] ../src/cookbook/deployment/rolling-update-migrations.md $lang:../src/$lang/cookbook/deployment/rolling-update-migrations.md pot=cookbook_deployment_rolling-update-migrations.md
 [type: markdown] ../src/cookbook/disabling-csrf-protection.md $lang:../src/$lang/cookbook/disabling-csrf-protection.md pot=cookbook_disabling-csrf-protection.md
 [type: markdown] ../src/cookbook/index.md $lang:../src/$lang/cookbook/index.md pot=cookbook_index.md
 [type: markdown] ../src/cookbook/making-http-requests.md $lang:../src/$lang/cookbook/making-http-requests.md pot=cookbook_making-http-requests.md

--- a/_translations/pot/cookbook_deployment_rolling-update-migrations.md.pot
+++ b/_translations/pot/cookbook_deployment_rolling-update-migrations.md.pot
@@ -1,0 +1,560 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title #
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Applying migrations during rolling updates"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Rolling updates keep old and new application instances running at the same "
+"time. This makes database changes more delicate than in a single-server "
+"deployment: both application versions must work with the same database while "
+"the deployment is in progress."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The safe rule is:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Apply database changes that are compatible with the current production code."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that starts using these database changes."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Remove obsolete database structures only after every old application "
+"instance is gone."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"This is often called the expand and contract pattern. First expand the "
+"schema so both versions can use it. Then move the application code. Finally "
+"contract the schema in a later deployment."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Why this matters"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"During a rolling update, requests may be served by different versions of the "
+"application:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old code that does not know about the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "new code that expects the new schema;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "background workers that may lag behind web instances;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "scheduled commands that may run during deployment."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"If a migration drops or renames a column before all old instances stop using "
+"it, old code fails. If code that requires a new column is deployed before "
+"the column exists, new code fails. The migration plan must keep every "
+"intermediate state valid."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Deployment flow"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Use this flow for changes that must not interrupt production traffic:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Create a migration that only adds compatible schema."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Apply this migration to production while the current application version is "
+"still running."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy the new application version with a rolling update."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Verify that all instances and workers run the new version."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"In a later release, apply cleanup migrations that remove old columns, "
+"indexes, tables, or compatibility code."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"For Yii applications, run migrations with the same command you use in "
+"regular deployments, for example:"
+msgstr ""
+
+#. type: Fenced code block (shell)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "./yii migrate\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Run migrations from a single deployment job or one dedicated console "
+"container. Do not let every rolling application instance run migrations on "
+"startup."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Adding a nullable column is usually compatible with old code:"
+msgstr ""
+
+#. type: Fenced code block (php)
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid ""
+"public function up(MigrationBuilder $b): void\n"
+"{\n"
+"    $cb = $b->columnBuilder();\n"
+"\n"
+"    $b->addColumn('user', 'display_name', $cb::string());\n"
+"}\n"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Then deploy code that writes and reads `display_name`."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "If the column must eventually be required:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add it as nullable."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes it for new and updated rows."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill existing rows in batches."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a `NOT NULL` constraint in a later migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Do not add a `NOT NULL` column without a database default while old code "
+"still inserts rows without that column."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Renaming a column"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Renaming is not compatible because old code uses the old name and new code "
+"uses the new name. Use a multi-release change instead:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add the new column."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it from the old column."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Deploy code that writes both columns and reads the new column with a "
+"fallback to the old one."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Wait until all old code is gone."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that uses only the new column."
+msgstr ""
+
+#. type: Bullet: '6. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column in a later cleanup migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "The same approach works for moving data to a different table."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Changing a column type"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Changing a column type in place may lock the table or break either the old "
+"or new code. Prefer a new column:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Add a column with the target type."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Backfill it in batches."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that writes both columns."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that reads the new column."
+msgstr ""
+
+#. type: Bullet: '5. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop the old column after all code uses the new one."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"For small tables, an in-place type change may be acceptable. For production "
+"tables with traffic, verify locking behavior on the exact database engine "
+"and version before applying it."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Dropping columns and tables"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Dropping is a cleanup step, not the first step:"
+msgstr ""
+
+#. type: Bullet: '1. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Deploy code that no longer reads or writes the column or table."
+msgstr ""
+
+#. type: Bullet: '2. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Confirm that old application instances, workers, and scheduled commands are "
+"stopped."
+msgstr ""
+
+#. type: Bullet: '3. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Confirm that no external reporting or maintenance scripts depend on it."
+msgstr ""
+
+#. type: Bullet: '4. '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Drop it in a separate migration."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"This makes rollback safer. If you need to roll back application code before "
+"cleanup, the old schema is still available."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Adding indexes and constraints"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Indexes and constraints may be logically compatible but operationally risky "
+"because they can lock tables."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For indexes:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "use online index creation when the database supports it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or "
+"command that is not wrapped in a transaction;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"for MySQL and MariaDB, check whether the operation can use online DDL for "
+"your table and engine."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "For constraints:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "clean invalid data before adding the constraint;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "add the constraint only after deployed code preserves it;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"for PostgreSQL, consider adding foreign keys and check constraints as `NOT "
+"VALID`, then validating them separately."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Keep long-running index creation and validation separate from unrelated "
+"schema changes so it is easier to monitor and retry them."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Data migrations"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"Data migrations that touch many rows should be safe to run while the "
+"application is live:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "make them idempotent so rerunning them does not corrupt data;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "process rows in small batches;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"avoid depending on current application service or entity logic because that "
+"logic changes over time;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "prefer forward-compatible values that both old and new code can handle;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "store progress when a backfill is too large for a single migration run."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"For very large backfills, use a console command or background job after the "
+"schema migration. The schema migration should prepare the database; the "
+"background process should move the data gradually."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Reverting"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"In production rolling deployments, reverting a destructive migration is "
+"often harder than deploying a corrective migration. Treat `down()` methods "
+"for destructive operations as a local-development convenience, not as the "
+"main production rollback plan."
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "A practical rollback plan is:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"before cleanup, roll back code only because old schema is still present;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"after cleanup, deploy a new forward migration that restores the required "
+"structure or compatibility;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"restore from backup only when data was actually lost and no forward repair "
+"is possible."
+msgstr ""
+
+#. type: Title ##
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+#, no-wrap
+msgid "Checklist"
+msgstr ""
+
+#. type: Plain text
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "Before applying a production migration, verify that:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the current production code works after the migration;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "the new code works before and after all instances are updated;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "old workers and scheduled commands are covered;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"inserts and updates keep required columns valid in every deployment phase;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid ""
+"long-running schema operations will not block production traffic "
+"unexpectedly;"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/deployment/rolling-update-migrations.md
+msgid "cleanup happens in a separate release after the rollout is complete."
+msgstr ""

--- a/_translations/pot/cookbook_index.md.pot
+++ b/_translations/pot/cookbook_index.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-09 10:43+0000\n"
+"POT-Creation-Date: 2026-05-30 09:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,4 +109,11 @@ msgstr ""
 #. type: Bullet: '- '
 #: ../src/cookbook/index.md
 msgid "[Deploying to Docker Swarm](deployment/docker-swarm.md)"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../src/cookbook/index.md
+msgid ""
+"[Applying migrations during rolling updates](deployment/rolling-update-"
+"migrations.md)"
 msgstr ""

--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -238,7 +238,8 @@ export default {
                         {
                             text: 'Deployment',
                             items: [
-                                {text: 'Docker Swarm', link: '/cookbook/deployment/docker-swarm'}
+                                {text: 'Docker Swarm', link: '/cookbook/deployment/docker-swarm'},
+                                {text: 'Rolling Update Migrations', link: '/cookbook/deployment/rolling-update-migrations'}
                             ]
                         }
                     ],

--- a/src/cookbook/deployment/rolling-update-migrations.md
+++ b/src/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,164 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same time. This makes database changes more
+delicate than in a single-server deployment: both application versions must work with the same database while the
+deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application instance is gone.
+
+This is often called the expand and contract pattern. First expand the schema so both versions can use it. Then move
+the application code. Finally contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using it, old code fails. If code that requires a
+new column is deployed before the column exists, new code fails. The migration plan must keep every intermediate state
+valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns, indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console container. Do not let every rolling application
+instance run migrations on startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code uses the new name. Use a multi-release
+change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production tables with traffic, verify locking behavior
+on the exact database engine and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or command that is not wrapped in a
+  transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated schema changes so it is easier to monitor and
+retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the schema migration. The schema migration should
+prepare the database; the background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is often harder than deploying a corrective
+migration. Treat `down()` methods for destructive operations as a local-development convenience, not as the main
+production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/cookbook/index.md
+++ b/src/cookbook/index.md
@@ -23,3 +23,4 @@ This book conforms to the [Terms of Yii Documentation](https://www.yiiframework.
 - [Configuring webservers](configuring-webservers/general.md)
 - [Structuring code by use-case with vertical slices](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [Deploying to Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling updates](deployment/rolling-update-migrations.md)

--- a/src/es/cookbook/deployment/rolling-update-migrations.md
+++ b/src/es/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,190 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same
+time. This makes database changes more delicate than in a single-server
+deployment: both application versions must work with the same database while
+the deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production
+   code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application
+   instance is gone.
+
+This is often called the expand and contract pattern. First expand the
+schema so both versions can use it. Then move the application code. Finally
+contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the
+application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using
+it, old code fails. If code that requires a new column is deployed before
+the column exists, new code fails. The migration plan must keep every
+intermediate state valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version
+   is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns,
+   indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in
+regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console
+container. Do not let every rolling application instance run migrations on
+startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code
+still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code
+uses the new name. Use a multi-release change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a
+   fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old
+or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production
+tables with traffic, verify locking behavior on the exact database engine
+and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands
+   are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before
+cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky
+because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or
+  command that is not wrapped in a transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for
+  your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT
+  VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated
+schema changes so it is easier to monitor and retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the
+application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because
+  that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the
+schema migration. The schema migration should prepare the database; the
+background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is
+often harder than deploying a corrective migration. Treat `down()` methods
+for destructive operations as a local-development convenience, not as the
+main production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required
+  structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair
+  is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic
+  unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/es/cookbook/index.md
+++ b/src/es/cookbook/index.md
@@ -26,3 +26,5 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Structuring code by use-case with vertical
   slices](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [Deploying to Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling
+  updates](deployment/rolling-update-migrations.md)

--- a/src/id/cookbook/deployment/rolling-update-migrations.md
+++ b/src/id/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,190 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same
+time. This makes database changes more delicate than in a single-server
+deployment: both application versions must work with the same database while
+the deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production
+   code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application
+   instance is gone.
+
+This is often called the expand and contract pattern. First expand the
+schema so both versions can use it. Then move the application code. Finally
+contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the
+application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using
+it, old code fails. If code that requires a new column is deployed before
+the column exists, new code fails. The migration plan must keep every
+intermediate state valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version
+   is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns,
+   indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in
+regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console
+container. Do not let every rolling application instance run migrations on
+startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code
+still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code
+uses the new name. Use a multi-release change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a
+   fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old
+or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production
+tables with traffic, verify locking behavior on the exact database engine
+and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands
+   are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before
+cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky
+because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or
+  command that is not wrapped in a transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for
+  your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT
+  VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated
+schema changes so it is easier to monitor and retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the
+application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because
+  that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the
+schema migration. The schema migration should prepare the database; the
+background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is
+often harder than deploying a corrective migration. Treat `down()` methods
+for destructive operations as a local-development convenience, not as the
+main production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required
+  structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair
+  is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic
+  unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/id/cookbook/index.md
+++ b/src/id/cookbook/index.md
@@ -26,3 +26,5 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Structuring code by use-case with vertical
   slices](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [Deploying to Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling
+  updates](deployment/rolling-update-migrations.md)

--- a/src/it/cookbook/deployment/rolling-update-migrations.md
+++ b/src/it/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,190 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same
+time. This makes database changes more delicate than in a single-server
+deployment: both application versions must work with the same database while
+the deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production
+   code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application
+   instance is gone.
+
+This is often called the expand and contract pattern. First expand the
+schema so both versions can use it. Then move the application code. Finally
+contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the
+application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using
+it, old code fails. If code that requires a new column is deployed before
+the column exists, new code fails. The migration plan must keep every
+intermediate state valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version
+   is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns,
+   indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in
+regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console
+container. Do not let every rolling application instance run migrations on
+startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code
+still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code
+uses the new name. Use a multi-release change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a
+   fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old
+or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production
+tables with traffic, verify locking behavior on the exact database engine
+and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands
+   are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before
+cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky
+because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or
+  command that is not wrapped in a transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for
+  your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT
+  VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated
+schema changes so it is easier to monitor and retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the
+application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because
+  that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the
+schema migration. The schema migration should prepare the database; the
+background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is
+often harder than deploying a corrective migration. Treat `down()` methods
+for destructive operations as a local-development convenience, not as the
+main production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required
+  structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair
+  is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic
+  unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/it/cookbook/index.md
+++ b/src/it/cookbook/index.md
@@ -26,3 +26,5 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Structuring code by use-case with vertical
   slices](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [Deploying to Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling
+  updates](deployment/rolling-update-migrations.md)

--- a/src/ru/cookbook/deployment/rolling-update-migrations.md
+++ b/src/ru/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,190 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same
+time. This makes database changes more delicate than in a single-server
+deployment: both application versions must work with the same database while
+the deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production
+   code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application
+   instance is gone.
+
+This is often called the expand and contract pattern. First expand the
+schema so both versions can use it. Then move the application code. Finally
+contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the
+application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using
+it, old code fails. If code that requires a new column is deployed before
+the column exists, new code fails. The migration plan must keep every
+intermediate state valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version
+   is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns,
+   indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in
+regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console
+container. Do not let every rolling application instance run migrations on
+startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code
+still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code
+uses the new name. Use a multi-release change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a
+   fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old
+or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production
+tables with traffic, verify locking behavior on the exact database engine
+and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands
+   are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before
+cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky
+because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or
+  command that is not wrapped in a transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for
+  your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT
+  VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated
+schema changes so it is easier to monitor and retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the
+application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because
+  that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the
+schema migration. The schema migration should prepare the database; the
+background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is
+often harder than deploying a corrective migration. Treat `down()` methods
+for destructive operations as a local-development convenience, not as the
+main production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required
+  structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair
+  is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic
+  unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/ru/cookbook/index.md
+++ b/src/ru/cookbook/index.md
@@ -26,3 +26,5 @@ Documentation](https://www.yiiframework.com/license#docs).
 - [Structuring code by use-case with vertical
   slices](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [Deploying to Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling
+  updates](deployment/rolling-update-migrations.md)

--- a/src/zh-CN/cookbook/deployment/rolling-update-migrations.md
+++ b/src/zh-CN/cookbook/deployment/rolling-update-migrations.md
@@ -1,0 +1,190 @@
+# Applying migrations during rolling updates
+
+Rolling updates keep old and new application instances running at the same
+time. This makes database changes more delicate than in a single-server
+deployment: both application versions must work with the same database while
+the deployment is in progress.
+
+The safe rule is:
+
+1. Apply database changes that are compatible with the current production
+   code.
+2. Deploy code that starts using these database changes.
+3. Remove obsolete database structures only after every old application
+   instance is gone.
+
+This is often called the expand and contract pattern. First expand the
+schema so both versions can use it. Then move the application code. Finally
+contract the schema in a later deployment.
+
+## Why this matters
+
+During a rolling update, requests may be served by different versions of the
+application:
+
+- old code that does not know about the new schema;
+- new code that expects the new schema;
+- background workers that may lag behind web instances;
+- scheduled commands that may run during deployment.
+
+If a migration drops or renames a column before all old instances stop using
+it, old code fails. If code that requires a new column is deployed before
+the column exists, new code fails. The migration plan must keep every
+intermediate state valid.
+
+## Deployment flow
+
+Use this flow for changes that must not interrupt production traffic:
+
+1. Create a migration that only adds compatible schema.
+2. Apply this migration to production while the current application version
+   is still running.
+3. Deploy the new application version with a rolling update.
+4. Verify that all instances and workers run the new version.
+5. In a later release, apply cleanup migrations that remove old columns,
+   indexes, tables, or compatibility code.
+
+For Yii applications, run migrations with the same command you use in
+regular deployments, for example:
+
+```shell
+./yii migrate
+```
+
+Run migrations from a single deployment job or one dedicated console
+container. Do not let every rolling application instance run migrations on
+startup.
+
+## Adding a column
+
+Adding a nullable column is usually compatible with old code:
+
+```php
+public function up(MigrationBuilder $b): void
+{
+    $cb = $b->columnBuilder();
+
+    $b->addColumn('user', 'display_name', $cb::string());
+}
+```
+
+Then deploy code that writes and reads `display_name`.
+
+If the column must eventually be required:
+
+1. Add it as nullable.
+2. Deploy code that writes it for new and updated rows.
+3. Backfill existing rows in batches.
+4. Add a `NOT NULL` constraint in a later migration.
+
+Do not add a `NOT NULL` column without a database default while old code
+still inserts rows without that column.
+
+## Renaming a column
+
+Renaming is not compatible because old code uses the old name and new code
+uses the new name. Use a multi-release change instead:
+
+1. Add the new column.
+2. Backfill it from the old column.
+3. Deploy code that writes both columns and reads the new column with a
+   fallback to the old one.
+4. Wait until all old code is gone.
+5. Deploy code that uses only the new column.
+6. Drop the old column in a later cleanup migration.
+
+The same approach works for moving data to a different table.
+
+## Changing a column type
+
+Changing a column type in place may lock the table or break either the old
+or new code. Prefer a new column:
+
+1. Add a column with the target type.
+2. Backfill it in batches.
+3. Deploy code that writes both columns.
+4. Deploy code that reads the new column.
+5. Drop the old column after all code uses the new one.
+
+For small tables, an in-place type change may be acceptable. For production
+tables with traffic, verify locking behavior on the exact database engine
+and version before applying it.
+
+## Dropping columns and tables
+
+Dropping is a cleanup step, not the first step:
+
+1. Deploy code that no longer reads or writes the column or table.
+2. Confirm that old application instances, workers, and scheduled commands
+   are stopped.
+3. Confirm that no external reporting or maintenance scripts depend on it.
+4. Drop it in a separate migration.
+
+This makes rollback safer. If you need to roll back application code before
+cleanup, the old schema is still available.
+
+## Adding indexes and constraints
+
+Indexes and constraints may be logically compatible but operationally risky
+because they can lock tables.
+
+For indexes:
+
+- use online index creation when the database supports it;
+- for PostgreSQL, consider `CREATE INDEX CONCURRENTLY` from a migration or
+  command that is not wrapped in a transaction;
+- for MySQL and MariaDB, check whether the operation can use online DDL for
+  your table and engine.
+
+For constraints:
+
+- clean invalid data before adding the constraint;
+- add the constraint only after deployed code preserves it;
+- for PostgreSQL, consider adding foreign keys and check constraints as `NOT
+  VALID`, then validating them separately.
+
+Keep long-running index creation and validation separate from unrelated
+schema changes so it is easier to monitor and retry them.
+
+## Data migrations
+
+Data migrations that touch many rows should be safe to run while the
+application is live:
+
+- make them idempotent so rerunning them does not corrupt data;
+- process rows in small batches;
+- avoid depending on current application service or entity logic because
+  that logic changes over time;
+- prefer forward-compatible values that both old and new code can handle;
+- store progress when a backfill is too large for a single migration run.
+
+For very large backfills, use a console command or background job after the
+schema migration. The schema migration should prepare the database; the
+background process should move the data gradually.
+
+## Reverting
+
+In production rolling deployments, reverting a destructive migration is
+often harder than deploying a corrective migration. Treat `down()` methods
+for destructive operations as a local-development convenience, not as the
+main production rollback plan.
+
+A practical rollback plan is:
+
+- before cleanup, roll back code only because old schema is still present;
+- after cleanup, deploy a new forward migration that restores the required
+  structure or compatibility;
+- restore from backup only when data was actually lost and no forward repair
+  is possible.
+
+## Checklist
+
+Before applying a production migration, verify that:
+
+- the current production code works after the migration;
+- the new code works before and after all instances are updated;
+- old workers and scheduled commands are covered;
+- inserts and updates keep required columns valid in every deployment phase;
+- long-running schema operations will not block production traffic
+  unexpectedly;
+- cleanup happens in a separate release after the rollout is complete.

--- a/src/zh-CN/cookbook/index.md
+++ b/src/zh-CN/cookbook/index.md
@@ -22,3 +22,5 @@ Yii3 社区手册是一本开源书籍，包含了关于 [Yii3](https://www.yiif
 - [配置 Web 服务器](configuring-webservers/general.md)
 - [使用垂直切片按用例组织代码](organizing-code/structuring-by-use-case-with-vertical-slices.md)
 - [部署到 Docker Swarm](deployment/docker-swarm.md)
+- [Applying migrations during rolling
+  updates](deployment/rolling-update-migrations.md)


### PR DESCRIPTION
## Summary
- add a cookbook recipe for rolling-update-safe database migration flow
- document expand/contract handling for common schema changes
- wire the recipe into the cookbook TOC, VitePress sidebar, and po4a config

## Tests
- bash scripts/check-links.sh src/cookbook/index.md src/cookbook/deployment/rolling-update-migrations.md
- npm run build

Fixes #268