### PR TITLE
Fix #453: Document custom form validation

### DIFF
--- a/src/guide/start/forms.md
+++ b/src/guide/start/forms.md
@@ -49,6 +49,93 @@ final class Form extends FormModel
 In the above example, the `Form` has a single string property `$message` which length should be at least
 of two characters. There's also a custom label for the property.
 
+## Custom validation <span id="custom-validation"></span>
+
+Validation attributes are Yii Validator rules. For common checks, first look for an existing rule. For example,
+to validate a UUID string, use `Uuid`:
+
+```php
+use Yiisoft\FormModel\FormModel;
+use Yiisoft\Validator\Rule\Uuid;
+
+final class Form extends FormModel
+{
+    #[Uuid]
+    public string $id = '';
+}
+```
+
+When a field needs application-specific validation that isn't covered by a built-in rule, use `Callback`. This is useful
+for one-off checks or for delegating to a domain/library method. With PHP attributes, use the `method` option because
+PHP attributes can't contain closures. For example, the following form validates a card number checksum:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\Echo;
+
+use Yiisoft\FormModel\FormModel;
+use Yiisoft\Validator\Label;
+use Yiisoft\Validator\Result;
+use Yiisoft\Validator\Rule\Callback;
+use Yiisoft\Validator\Rule\Required;
+use Yiisoft\Validator\ValidationContext;
+
+final class Form extends FormModel
+{
+    #[Label('Card number')]
+    #[Required]
+    #[Callback(method: 'validateCardNumberChecksum', skipOnError: true)]
+    public string $cardNumber = '';
+
+    private function validateCardNumberChecksum(mixed $value, Callback $rule, ValidationContext $context): Result
+    {
+        if (!is_string($value)) {
+            return (new Result())->addError('Card number must be a string.');
+        }
+
+        $digits = str_replace([' ', '-'], '', $value);
+
+        if ($digits === '' || !ctype_digit($digits)) {
+            return (new Result())->addError('Card number must contain digits only.');
+        }
+
+        $sum = 0;
+        $double = false;
+
+        foreach (array_reverse(str_split($digits)) as $digit) {
+            $number = (int) $digit;
+
+            if ($double) {
+                $number *= 2;
+                if ($number > 9) {
+                    $number -= 9;
+                }
+            }
+
+            $sum += $number;
+            $double = !$double;
+        }
+
+        if ($sum % 10 !== 0) {
+            return (new Result())->addError('Card number checksum is invalid.');
+        }
+
+        return new Result();
+    }
+}
+```
+
+The callback method returns a `Result`: return an empty result when the value is valid or add an error when it isn't.
+The method body can call any validation code your application already uses, such as
+`App\Payment\CardNumber::hasValidChecksum($value)`.
+
+For validation logic reused in several forms, create a custom Yii Validator rule and handler instead of copying callback
+methods. See the [custom rule guide](https://github.com/yiisoft/validator/blob/master/docs/guide/en/creating-custom-rules.md)
+for the rule/handler structure.
+
 ## Using the form <span id="using-form"></span> 
 
 Now that you have a form, use it in your action from "[Saying Hello](hello.md)".


### PR DESCRIPTION
## Summary
- add a custom validation section to the forms guide
- show built-in UUID validation and a Callback-based card number checksum example
- link to the validator custom rule guide for reusable rules

## Testing
- npm run build
- fresh yiisoft/app checkout: composer install, composer require yiisoft/form-model, php check-form-validation.php

Fixes #453