### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,14 +8,19 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   build:
+    permissions:
+      checks: write
+      contents: read
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Fetch styles
         run: |
@@ -24,7 +29,7 @@ jobs:
           unzip Microsoft.zip -d .github/styles
 
       - name: Check
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a
         with:
           reporter: github-check
           fail_on_error: false
@@ -37,9 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Find files to check
         id: links
@@ -82,7 +88,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.links.outputs.count != '0'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,18 +7,23 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: read # Required to check out repository contents.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
+    name: Build documentation
     permissions:
-      checks: write
-      contents: read
+      checks: write # Required by vale-action to publish check annotations.
+      contents: read # Required to check out repository contents.
 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -29,7 +34,7 @@ jobs:
           unzip Microsoft.zip -d .github/styles
 
       - name: Check
-        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a
+        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # tag = reviewdog
         with:
           reporter: github-check
           fail_on_error: false
@@ -39,10 +44,11 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   links:
+    name: Check links
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -50,13 +56,18 @@ jobs:
       - name: Find files to check
         id: links
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git diff --name-status --diff-filter=ACMRTD "${{ github.event.pull_request.base.sha }}...HEAD" > changed-files.txt
-          elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-            git diff-tree --root --no-commit-id --name-status -r "${{ github.sha }}" > changed-files.txt
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git diff --name-status --diff-filter=ACMRTD "$PR_BASE_SHA...HEAD" > changed-files.txt
+          elif [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            git diff-tree --root --no-commit-id --name-status -r "$CURRENT_SHA" > changed-files.txt
           else
-            git diff --name-status --diff-filter=ACMRTD "${{ github.event.before }}..${{ github.sha }}" > changed-files.txt
+            git diff --name-status --diff-filter=ACMRTD "$BEFORE_SHA..$CURRENT_SHA" > changed-files.txt
           fi
 
           check_all=false
@@ -88,7 +99,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.links.outputs.count != '0'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -20,10 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -35,12 +35,16 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
           path: src/.vitepress/dist
 
   deploy:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      pages: write
+      id-token: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -49,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: read # Required to check out repository contents.
 
 concurrency:
   group: "pages"
@@ -15,15 +15,16 @@ concurrency:
 
 jobs:
   build:
+    name: Build site
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -35,15 +36,16 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: src/.vitepress/dist
 
   deploy:
+    name: Deploy site
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     permissions:
-      pages: write
-      id-token: write
+      pages: write # Required to publish to GitHub Pages.
+      id-token: write # Required to authenticate the Pages deployment.
 
     environment:
       name: github-pages
@@ -53,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -11,14 +11,22 @@ on:
       - 'src/**'
 
 permissions:
-  contents: write
+  contents: read # Required to check out repository contents by default.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-docs:
     name: Update docs
+    permissions:
+      contents: write # Required to push generated translation updates.
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
           ref: ${{ github.head_ref }}
@@ -29,7 +37,7 @@ jobs:
         run: _translations/prepare-config.sh
 
       - name: Use po4a
-        uses: vjik/docker-run@623c9adf6ee99fc8f9fa4e3b0b6b0c25859b69ee
+        uses: vjik/docker-run@623c9adf6ee99fc8f9fa4e3b0b6b0c25859b69ee # v1
         with:
           image: ghcr.io/yiisoft-contrib/po4a:0.74
           volumes: ${{ github.workspace }}:/src
@@ -42,7 +50,18 @@ jobs:
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changed files
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
-        with:
-          commit_message: Update translation
-          file_pattern: '_translations src'
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          git add _translations src
+
+          if git diff --cached --quiet; then
+            echo "No translation changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Update translation"
+          git push

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,7 +1,7 @@
 name: Update translations
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '_translations/**'
   push:
@@ -10,31 +10,39 @@ on:
       - '_translations/**'
       - 'src/**'
 
+permissions:
+  contents: write
 jobs:
   update-docs:
     name: Update docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Prepare po4a configuration
         run: _translations/prepare-config.sh
 
       - name: Use po4a
-        uses: vjik/docker-run@v1
+        uses: vjik/docker-run@623c9adf6ee99fc8f9fa4e3b0b6b0c25859b69ee
         with:
           image: ghcr.io/yiisoft-contrib/po4a:0.74
           volumes: ${{ github.workspace }}:/src
           workdir: /src/_translations
           command: po4a po4a.conf && po4a po4a.conf
 
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
+
       - name: Commit changed files
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
         with:
           commit_message: Update translation
           file_pattern: '_translations src'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating service image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check